### PR TITLE
fix(dashboard): persist dark/light theme preference

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -11,10 +11,49 @@
   let risksView = 'matrix';
   let charts = {};
   const EVIDENCE_PER_PAGE = 10;
+  const THEME_KEY = 'em-dash-theme';
+
+  function getSavedTheme() {
+    const savedTheme = localStorage.getItem(THEME_KEY);
+    return savedTheme === 'dark' || savedTheme === 'light' ? savedTheme : null;
+  }
+
+  function applyTheme(theme) {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem(THEME_KEY, theme);
+    updateThemeToggleLabel(theme);
+  }
+
+  function updateThemeToggleLabel(theme) {
+    const button = document.getElementById('theme-toggle');
+    if (button) button.textContent = theme === 'dark' ? 'Light mode' : 'Dark mode';
+  }
+
+  function setupThemeToggle() {
+    const button = document.getElementById('theme-toggle');
+    if (!button) return;
+
+    const savedTheme = getSavedTheme();
+    if (savedTheme) {
+      applyTheme(savedTheme);
+    } else {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      updateThemeToggleLabel(systemTheme);
+    }
+
+    button.addEventListener('click', () => {
+      const currentTheme = document.documentElement.dataset.theme
+        || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      applyTheme(nextTheme);
+    });
+  }
 
   // ─── Init ───────────────────────────────────────────────
 
   async function init() {
+    setupThemeToggle();
+
     // Configure Chart.js defaults
     if (typeof Chart !== 'undefined') {
       Chart.defaults.font.family = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,6 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>em-dash</title>
+  <script>
+    (function () {
+      const key = 'em-dash-theme';
+      const savedTheme = localStorage.getItem(key);
+      if (savedTheme === 'dark' || savedTheme === 'light') {
+        document.documentElement.dataset.theme = savedTheme;
+      }
+    })();
+  </script>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' font-family='monospace'>—</text></svg>">
   <link rel="stylesheet" href="/style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
@@ -67,6 +76,7 @@
           <span class="header-project" id="project-name">Loading...</span>
         </div>
         <div class="header-right">
+          <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle theme">Dark mode</button>
           <div class="score-ring" id="score-ring">
             <svg viewBox="0 0 36 36" role="img" aria-label="Compliance percentage">
               <path class="ring-bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"/>

--- a/dashboard/style.css
+++ b/dashboard/style.css
@@ -43,8 +43,43 @@
   --mono: 'SF Mono', 'Fira Code', 'Consolas', monospace;
 }
 
+:root[data-theme="light"] {
+  --bg: #fafafa;
+  --surface: #ffffff;
+  --border: #e5e5e5;
+  --text: #1a1a1a;
+  --text-secondary: #666666;
+  --accent: #2563eb;
+  --accent-light: #dbeafe;
+  --green: #16a34a;
+  --green-light: #dcfce7;
+  --yellow: #ca8a04;
+  --yellow-light: #fef9c3;
+  --red: #dc2626;
+  --red-light: #fee2e2;
+  --orange: #ea580c;
+  --orange-light: #fff7ed;
+  --purple: #7c3aed;
+  --purple-light: #ede9fe;
+}
+
+:root[data-theme="dark"] {
+  --bg: #0a0a0a;
+  --surface: #141414;
+  --border: #2a2a2a;
+  --text: #e5e5e5;
+  --text-secondary: #999999;
+  --accent: #3b82f6;
+  --accent-light: #1e3a5f;
+  --green-light: #052e16;
+  --yellow-light: #422006;
+  --red-light: #450a0a;
+  --orange-light: #431407;
+  --purple-light: #2e1065;
+}
+
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --bg: #0a0a0a;
     --surface: #141414;
     --border: #2a2a2a;
@@ -242,6 +277,24 @@ header {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.theme-toggle {
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-family: var(--font);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.theme-toggle:hover {
+  background: var(--bg);
+  color: var(--text);
 }
 
 .score-ring {


### PR DESCRIPTION
## Summary
- add a dashboard theme toggle in the header
- persist selected theme (`dark`/`light`) in localStorage
- apply saved theme before first paint to avoid flash on reload
- keep system `prefers-color-scheme` as fallback when no saved preference exists

## Testing
- `git diff --check`
- `bun test test/skill-validation.test.ts test/rego-policy.test.ts test/bin-smoke.test.ts test/touchfiles.test.ts` *(fails in this environment: `bun: command not found`)*

Closes #8