### PR TITLE
templates: add workforce training policy

### DIFF
--- a/templates/policies/workforce-training.md
+++ b/templates/policies/workforce-training.md
@@ -1,0 +1,68 @@
+# Workforce Training Policy
+
+**Organization:** {ORGANIZATION_NAME}
+**Policy Owner:** {SECURITY_OFFICER}
+**Effective Date:** {DATE}
+**Last Reviewed:** {DATE}
+**Version:** 1.0
+
+## 1. Purpose
+
+This policy establishes the security awareness and workforce training requirements for all workforce members at {ORGANIZATION_NAME}, in support of HIPAA Security Rule 164.308(a)(5)(i). The goal is to ensure workforce members understand how to protect electronic protected health information (ePHI), recognize common security threats, and follow approved reporting and response procedures.
+
+## 2. Scope
+
+This policy applies to all employees, contractors, temporary staff, interns, and other workforce members who access, support, or administer systems that create, receive, maintain, or transmit ePHI on behalf of {ORGANIZATION_NAME}.
+
+## 3. Training Requirements
+
+### 3.1 New Hire Training
+
+- All workforce members must complete security awareness and HIPAA training before receiving access to systems containing ePHI.
+- Training must cover the workforce member's responsibilities for protecting ePHI, following approved procedures, and reporting security concerns promptly.
+- Managers and system owners must confirm training completion before system access is approved.
+
+### 3.2 Ongoing Refresher Training
+
+- All workforce members must complete refresher training at least annually.
+- Additional training must be assigned when material policies, procedures, technology, or threat conditions change.
+- Workforce members with elevated privileges or specialized access may receive role-specific supplemental training.
+
+## 4. Topics Covered
+
+Training content must address, at minimum:
+
+- Proper handling, use, storage, and disclosure of ePHI
+- Password management, multi-factor authentication, and credential protection
+- Phishing, social engineering, and suspicious communication awareness
+- Incident reporting requirements and escalation paths
+- Secure workstation, device, and remote access practices
+- Physical security basics for offices, shared spaces, and portable devices
+
+## 5. Training Records and Documentation
+
+- {ORGANIZATION_NAME} must maintain records of assigned and completed training for all workforce members.
+- Training records must include the workforce member name, training title, completion date, and any required acknowledgment.
+- Records must be retained for at least six years or longer if required by contract, policy, or law.
+- {SECURITY_OFFICER} is responsible for reviewing training completion records and following up on overdue assignments.
+
+## 6. Sanctions for Non-Compliance
+
+- Failure to complete required training by assigned deadlines may result in suspension or removal of system access.
+- Repeated failure to complete required training, or failure to follow trained procedures, may result in disciplinary action up to and including termination of employment or contract.
+- Sanctions must be applied consistently with the organization's workforce security and sanctions processes.
+
+## 7. Remote Worker Requirements
+
+- Workforce members performing remote work must complete training on secure remote access, home network hygiene, and approved device use.
+- Remote workers must understand requirements for screen privacy, device locking, secure storage of work materials, and reporting lost or stolen devices.
+- Remote access to systems containing ePHI must use only organization-approved tools and configurations.
+
+## 8. Review Schedule
+
+This policy must be reviewed annually, and sooner if there are material changes to HIPAA requirements, security awareness expectations, training content, or the organization's operating environment.
+
+---
+
+*Approved by:* {SECURITY_OFFICER}
+*Approval Date:* {DATE}

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -198,11 +198,12 @@ describe('Policy templates', () => {
     'incident-response.md',
     'risk-assessment.md',
     'workforce-security.md',
+    'workforce-training.md',
     'contingency-plan.md',
     'baa-template.md',
   ];
 
-  test('all 8 policy templates exist', () => {
+  test('all 9 policy templates exist', () => {
     for (const policy of expectedPolicies) {
       expect(fs.existsSync(path.join(policyDir, policy))).toBe(true);
     }


### PR DESCRIPTION
Closes #7

## Summary
- add a new `workforce-training.md` HIPAA policy template under `templates/policies/`
- cover new-hire and annual training, required topics, recordkeeping, sanctions, and remote worker requirements
- update the policy template expectation list in `test/skill-validation.test.ts`

## Verification
- ran `bun test test/skill-validation.test.ts test/rego-policy.test.ts test/bin-smoke.test.ts test/touchfiles.test.ts`
- full suite has existing Windows-local failures around executable bits/bin smoke tests and stale generated skill docs
- confirmed the policy template checks for `workforce-training.md` pass in `test/skill-validation.test.ts`
