### PR TITLE
feat: persona-driven skill architecture — journey engine, PR gate, new skills

### DIFF
--- a/bin/comply-check
+++ b/bin/comply-check
@@ -1,0 +1,345 @@
+#!/usr/bin/env bun
+/**
+ * comply-check — PR-level compliance gate.
+ *
+ * Checks a git diff for compliance issues: PHI patterns, sensitive data exposure,
+ * removed security controls, new dependencies requiring BAAs.
+ *
+ * Usage:
+ *   comply-check --diff HEAD~1 [--severity warn] [--json]
+ *   comply-check --diff main   [--severity block]
+ *
+ * Exit codes:
+ *   0 — clean (no findings at or above severity threshold)
+ *   1 — findings detected at or above severity threshold
+ *   2 — error (bad args, git failure, etc.)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const args = process.argv.slice(2);
+
+function getFlag(name: string): string {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return '';
+  return args[idx + 1];
+}
+
+const diffRef = getFlag('diff');
+const severity = getFlag('severity') || 'warn';
+const jsonOutput = args.includes('--json');
+
+if (!diffRef) {
+  console.error('Usage: comply-check --diff <ref> [--severity info|warn|block] [--json]');
+  console.error('  e.g.: comply-check --diff HEAD~1');
+  console.error('  e.g.: comply-check --diff main --severity block');
+  process.exit(2);
+}
+
+// ─── Severity levels ───────────────────────────────────────
+
+const SEVERITY_ORDER: Record<string, number> = {
+  'INFO': 0, 'LOW': 1, 'MEDIUM': 2, 'HIGH': 3, 'CRITICAL': 4
+};
+const THRESHOLD: Record<string, string> = {
+  'info': 'INFO', 'warn': 'HIGH', 'block': 'CRITICAL'
+};
+const thresholdSeverity = THRESHOLD[severity] || 'HIGH';
+
+// ─── Load checks registry (code_grep checks only) ─────────
+
+interface CodeCheck {
+  id: string;
+  description: string;
+  pattern: string;
+  severity: string;
+  category: string;
+}
+
+function loadCodeChecks(): CodeCheck[] {
+  const registryPath = path.join(import.meta.dir, '..', 'frameworks', 'checks-registry.ts');
+  const content = fs.readFileSync(registryPath, 'utf-8');
+
+  // Extract code_grep checks by parsing the array literals
+  const checks: CodeCheck[] = [];
+  const checkRegex = /\{\s*id:\s*"([^"]+)"[\s\S]*?category:\s*"([^"]+)"[\s\S]*?description:\s*"([^"]+)"[\s\S]*?type:\s*"code_grep"[\s\S]*?pattern:\s*"([^"]+)"[\s\S]*?severity_default:\s*"([^"]+)"/g;
+
+  let match;
+  while ((match = checkRegex.exec(content)) !== null) {
+    checks.push({
+      id: match[1],
+      category: match[2],
+      description: match[3],
+      pattern: match[4],
+      severity: match[5],
+    });
+  }
+  return checks;
+}
+
+// ─── Load BAA vendor list ──────────────────────────────────
+
+interface BAAVendor {
+  name: string;
+  packages: string[];
+  baa_required: boolean;
+  note?: string;
+}
+
+function loadBAAVendors(): BAAVendor[] {
+  const vendorPath = path.join(import.meta.dir, '..', 'nist', 'baa-vendors.json');
+  if (!fs.existsSync(vendorPath)) return [];
+  try {
+    const data = JSON.parse(fs.readFileSync(vendorPath, 'utf-8'));
+    return data.vendors || [];
+  } catch {
+    return [];
+  }
+}
+
+// ─── Load plain-english descriptions ───────────────────────
+
+function loadPlainEnglish(): Record<string, { plain_english: string }> {
+  const p = path.join(import.meta.dir, '..', 'nist', 'plain-english.json');
+  if (!fs.existsSync(p)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+// ─── Load tool bindings (check → control mapping) ──────────
+
+function loadToolBindings(): Record<string, { checks?: string[] }> {
+  const p = path.join(import.meta.dir, '..', 'nist', 'tool-bindings.json');
+  if (!fs.existsSync(p)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function checkIdToControlId(checkId: string, bindings: Record<string, any>): string | null {
+  for (const [controlId, binding] of Object.entries(bindings)) {
+    if (binding.checks && Array.isArray(binding.checks)) {
+      for (const check of binding.checks) {
+        const id = typeof check === 'string' ? check : check.id;
+        if (id === checkId) return controlId;
+      }
+    }
+  }
+  return null;
+}
+
+// ─── Get diff ──────────────────────────────────────────────
+
+interface DiffFile {
+  path: string;
+  content: string;
+  addedLines: { num: number; text: string }[];
+}
+
+async function getDiffFiles(): Promise<DiffFile[]> {
+  // Get list of changed files
+  const nameProc = Bun.spawnSync(['git', 'diff', diffRef, '--name-only', '--diff-filter=ACMR'], {
+    stdout: 'pipe', stderr: 'pipe'
+  });
+  const names = new TextDecoder().decode(nameProc.stdout).trim().split('\n').filter(Boolean);
+
+  const files: DiffFile[] = [];
+  for (const name of names) {
+    // Skip binary files and non-code files
+    if (/\.(png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|pdf|zip|tar|gz)$/i.test(name)) continue;
+
+    // Get added lines from the diff
+    const diffProc = Bun.spawnSync(['git', 'diff', diffRef, '--', name], {
+      stdout: 'pipe', stderr: 'pipe'
+    });
+    const diffOutput = new TextDecoder().decode(diffProc.stdout);
+
+    // Parse added lines (lines starting with +, excluding +++ header)
+    const addedLines: { num: number; text: string }[] = [];
+    let lineNum = 0;
+    for (const line of diffOutput.split('\n')) {
+      const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)/);
+      if (hunkMatch) {
+        lineNum = parseInt(hunkMatch[1]) - 1;
+        continue;
+      }
+      if (line.startsWith('+') && !line.startsWith('+++')) {
+        lineNum++;
+        addedLines.push({ num: lineNum, text: line.slice(1) });
+      } else if (!line.startsWith('-')) {
+        lineNum++;
+      }
+    }
+
+    // Read full file content for context
+    let content = '';
+    try {
+      content = fs.readFileSync(name, 'utf-8');
+    } catch {
+      // File might not exist (deleted)
+    }
+
+    if (addedLines.length > 0) {
+      files.push({ path: name, content, addedLines });
+    }
+  }
+  return files;
+}
+
+// ─── Check for new BAA-requiring dependencies ──────────────
+
+function checkNewDependencies(files: DiffFile[], vendors: BAAVendor[]): Finding[] {
+  const findings: Finding[] = [];
+
+  for (const file of files) {
+    if (!file.path.endsWith('package.json')) continue;
+
+    for (const vendor of vendors) {
+      for (const pkg of vendor.packages) {
+        for (const line of file.addedLines) {
+          if (line.text.includes(`"${pkg}"`)) {
+            findings.push({
+              file: file.path,
+              line: line.num,
+              check_id: 'baa-vendor-dependency',
+              control_id: null,
+              severity: vendor.baa_required ? 'HIGH' : 'MEDIUM',
+              description: `New dependency "${pkg}" (${vendor.name}) ${vendor.baa_required ? 'requires a BAA' : 'may need a BAA'}. ${vendor.note || ''}`.trim(),
+              category: 'vendor_baa',
+            });
+          }
+        }
+      }
+    }
+  }
+  return findings;
+}
+
+// ─── Run checks ────────────────────────────────────────────
+
+interface Finding {
+  file: string;
+  line: number;
+  check_id: string;
+  control_id: string | null;
+  severity: string;
+  description: string;
+  category: string;
+}
+
+function runCodeChecks(files: DiffFile[], checks: CodeCheck[], bindings: Record<string, any>): Finding[] {
+  const findings: Finding[] = [];
+
+  for (const file of files) {
+    for (const check of checks) {
+      try {
+        const regex = new RegExp(check.pattern, 'gi');
+        for (const line of file.addedLines) {
+          if (regex.test(line.text)) {
+            const controlId = checkIdToControlId(check.id, bindings);
+            findings.push({
+              file: file.path,
+              line: line.num,
+              check_id: check.id,
+              control_id: controlId,
+              severity: check.severity,
+              description: check.description,
+              category: check.category,
+            });
+            regex.lastIndex = 0; // Reset for next line
+          }
+        }
+      } catch {
+        // Invalid regex pattern, skip this check
+      }
+    }
+  }
+  return findings;
+}
+
+// ─── Main ──────────────────────────────────────────────────
+
+async function main() {
+  const checks = loadCodeChecks();
+  const vendors = loadBAAVendors();
+  const bindings = loadToolBindings();
+  const plainEnglish = loadPlainEnglish();
+
+  if (checks.length === 0) {
+    console.error('WARNING: No code_grep checks loaded from checks-registry.ts');
+  }
+
+  let files: DiffFile[];
+  try {
+    files = await getDiffFiles();
+  } catch (e: any) {
+    console.error(`Error reading diff: ${e.message}`);
+    process.exit(2);
+  }
+
+  if (files.length === 0) {
+    if (jsonOutput) {
+      console.log(JSON.stringify({ findings: [], summary: { total: 0, files_checked: 0 } }));
+    } else {
+      console.log('No changed files to check.');
+    }
+    process.exit(0);
+  }
+
+  // Run checks
+  const codeFindings = runCodeChecks(files, checks, bindings);
+  const depFindings = checkNewDependencies(files, vendors);
+  const allFindings = [...codeFindings, ...depFindings];
+
+  // Enrich with plain-english descriptions
+  for (const f of allFindings) {
+    if (f.control_id && plainEnglish[f.control_id]) {
+      (f as any).plain_english = plainEnglish[f.control_id].plain_english;
+    }
+  }
+
+  // Filter by severity threshold
+  const thresholdNum = SEVERITY_ORDER[thresholdSeverity] ?? 3;
+  const gatedFindings = allFindings.filter(f => (SEVERITY_ORDER[f.severity] ?? 0) >= thresholdNum);
+
+  // Output
+  if (jsonOutput) {
+    console.log(JSON.stringify({
+      findings: allFindings,
+      summary: {
+        total: allFindings.length,
+        above_threshold: gatedFindings.length,
+        threshold: thresholdSeverity,
+        files_checked: files.length,
+        checks_run: checks.length,
+      }
+    }, null, 2));
+  } else {
+    if (allFindings.length === 0) {
+      console.log(`✓ No compliance findings in ${files.length} changed files (${checks.length} checks run)`);
+    } else {
+      console.log(`Found ${allFindings.length} compliance finding(s) in ${files.length} changed files:\n`);
+      for (const f of allFindings) {
+        const marker = (SEVERITY_ORDER[f.severity] ?? 0) >= thresholdNum ? '✗' : '⚠';
+        console.log(`  ${marker} [${f.severity}] ${f.file}:${f.line}`);
+        console.log(`    ${f.description}`);
+        if (f.control_id) {
+          const pe = plainEnglish[f.control_id];
+          console.log(`    NIST: ${f.control_id}${pe ? ` — ${pe.plain_english}` : ''}`);
+        }
+        console.log('');
+      }
+      console.log(`${gatedFindings.length} finding(s) at or above ${thresholdSeverity} threshold.`);
+    }
+  }
+
+  process.exit(gatedFindings.length > 0 ? 1 : 0);
+}
+
+main();

--- a/bin/comply-db
+++ b/bin/comply-db
@@ -17,6 +17,8 @@
  *   hipaa-sections <id>        Reverse-map: NIST control → HIPAA CFR sections + category
  *   audit-snapshot <create|update|list|get>  Manage audit snapshots
  *   audit-diff --id1 <N> --id2 <N>          Compare two audit snapshots
+ *   journey <init|status|skip|complete>     Manage compliance journey milestones
+ *   config <get|set> <key> [value]          User preferences (~/.em-dash/config.json)
  *   query <sql>                Run raw SQL (for debugging)
  */
 
@@ -111,6 +113,158 @@ function extractParts(parts: any[]): string {
     if (part.parts) result += extractParts(part.parts);
   }
   return result.trim();
+}
+
+// ─── Explain Helpers ────────────────────────────────────────
+
+const PLAIN_ENGLISH_PATH = path.join(NIST_DIR, 'plain-english.json');
+const TOOL_BINDINGS_PATH = path.join(NIST_DIR, 'tool-bindings.json');
+const HIPAA_JSON_PATH = path.join(import.meta.dir, '..', 'frameworks', 'hipaa.json');
+
+/** Known tool keys in tool-bindings.json (everything else is metadata) */
+const TOOL_KEYS = ['emdash', 'prowler', 'checkov', 'trivy', 'lynis'];
+
+function loadPlainEnglish(controlId: string): { plain_english: string; why_it_matters: string; nist_name: string } | null {
+  try {
+    if (!fs.existsSync(PLAIN_ENGLISH_PATH)) return null;
+    const data = JSON.parse(fs.readFileSync(PLAIN_ENGLISH_PATH, 'utf-8'));
+    return data[controlId] || null;
+  } catch { return null; }
+}
+
+function extractGuidance(catalog: any, controlId: string): string {
+  const id = controlId.toLowerCase();
+  for (const group of catalog.catalog.groups) {
+    for (const ctrl of group.controls || []) {
+      if (ctrl.id === id) {
+        const guidancePart = ctrl.parts?.find((p: any) => p.name === 'guidance');
+        return guidancePart?.prose || '';
+      }
+      for (const enh of ctrl.controls || []) {
+        if (enh.id === id) {
+          const guidancePart = enh.parts?.find((p: any) => p.name === 'guidance');
+          return guidancePart?.prose || '';
+        }
+      }
+    }
+  }
+  return '';
+}
+
+/** Build an index of controlId → title from the full NIST catalog */
+function buildCatalogIndex(catalog: any): Record<string, string> {
+  const index: Record<string, string> = {};
+  for (const group of catalog.catalog.groups) {
+    for (const ctrl of group.controls || []) {
+      index[ctrl.id.toUpperCase()] = ctrl.title;
+      for (const enh of ctrl.controls || []) {
+        index[enh.id.toUpperCase()] = enh.title || ctrl.title;
+      }
+    }
+  }
+  return index;
+}
+
+function extractRelatedControls(catalog: any, controlId: string, catalogIndex: Record<string, string>): { id: string; title: string }[] {
+  const id = controlId.toLowerCase();
+  for (const group of catalog.catalog.groups) {
+    for (const ctrl of group.controls || []) {
+      if (ctrl.id === id) {
+        return (ctrl.links || [])
+          .filter((l: any) => l.rel === 'related')
+          .map((l: any) => {
+            const refId = l.href.replace('#', '').toUpperCase();
+            return { id: refId, title: catalogIndex[refId] || refId };
+          });
+      }
+      for (const enh of ctrl.controls || []) {
+        if (enh.id === id) {
+          return (enh.links || [])
+            .filter((l: any) => l.rel === 'related')
+            .map((l: any) => {
+              const refId = l.href.replace('#', '').toUpperCase();
+              return { id: refId, title: catalogIndex[refId] || refId };
+            });
+        }
+      }
+    }
+  }
+  return [];
+}
+
+function resolveFromCFR(cfrSection: string): string[] {
+  try {
+    const filterPath = path.join(NIST_DIR, 'hipaa-filter.json');
+    if (!fs.existsSync(filterPath)) return [];
+    const filter = JSON.parse(fs.readFileSync(filterPath, 'utf-8'));
+    const controls = filter.mapping[cfrSection];
+    return Array.isArray(controls) ? controls : [];
+  } catch { return []; }
+}
+
+function normalizeVerification(controlId: string): { automated: boolean; tools: string[]; checks: string[]; interview_only: boolean } | null {
+  try {
+    if (!fs.existsSync(TOOL_BINDINGS_PATH)) return null;
+    const bindings = JSON.parse(fs.readFileSync(TOOL_BINDINGS_PATH, 'utf-8'));
+    const binding = bindings.bindings[controlId];
+    if (!binding) return null;
+
+    const tools: string[] = [];
+    const checks: string[] = [];
+    for (const key of TOOL_KEYS) {
+      const arr = binding[key];
+      if (Array.isArray(arr) && arr.length > 0) {
+        tools.push(key);
+        checks.push(...arr);
+      }
+    }
+
+    return {
+      automated: tools.length > 0,
+      tools,
+      checks,
+      interview_only: binding.interview_only === true,
+    };
+  } catch { return null; }
+}
+
+function getHipaaName(cfrSections: string[]): string | null {
+  try {
+    if (!fs.existsSync(HIPAA_JSON_PATH)) return null;
+    const hipaa = JSON.parse(fs.readFileSync(HIPAA_JSON_PATH, 'utf-8'));
+    // Use checklist array (more complete than requirements: 35 vs 25 entries)
+    for (const cfr of cfrSections) {
+      const item = hipaa.checklist?.find((c: any) => c.id === cfr);
+      if (item) return item.text.split('—')[0]?.trim() || item.text;
+    }
+    // Fallback to requirements
+    for (const cfr of cfrSections) {
+      const req = hipaa.requirements?.find((r: any) => r.id === cfr);
+      if (req) return req.name;
+    }
+    return null;
+  } catch { return null; }
+}
+
+function getDetectedStack(dbPath: string): string[] {
+  try {
+    if (!fs.existsSync(dbPath)) return [];
+    const db = new Database(dbPath, { readonly: true });
+    // vendor_registry is created by comply-start apply, not by comply-db init
+    try {
+      const vendors = db.prepare('SELECT vendor FROM vendor_registry').all() as any[];
+      db.close();
+      return vendors.map((v: any) => v.vendor).filter(Boolean);
+    } catch {
+      db.close();
+      return [];
+    }
+  } catch { return []; }
+}
+
+/** Check if input looks like a HIPAA CFR section (e.g., 164.312(a)(2)(iv)) */
+function isCFRSection(input: string): boolean {
+  return /^164\.\d{3}/.test(input);
 }
 
 // ─── Schema ─────────────────────────────────────────────────
@@ -233,6 +387,57 @@ function migrateSchema(db: InstanceType<typeof Database>) {
     );
   `);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_audit_findings_snapshot ON audit_findings(snapshot_id);`);
+
+  // Onboarding tables (for comply-start)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS phi_data_flows (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      source            TEXT NOT NULL,
+      destination       TEXT NOT NULL,
+      data_type         TEXT NOT NULL,
+      encryption_status TEXT,
+      notes             TEXT,
+      created_at        TEXT DEFAULT (datetime('now'))
+    );
+  `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS vendor_registry (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      vendor            TEXT NOT NULL,
+      services_used     TEXT,
+      baa_status        TEXT DEFAULT 'unknown',
+      phi_scope         TEXT,
+      detected_from     TEXT,
+      confirmed_by_user INTEGER DEFAULT 0,
+      notes             TEXT,
+      created_at        TEXT DEFAULT (datetime('now'))
+    );
+  `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS action_items (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      priority          INTEGER NOT NULL,
+      control_id        TEXT,
+      description       TEXT NOT NULL,
+      effort            TEXT,
+      status            TEXT DEFAULT 'pending',
+      phase             TEXT,
+      created_at        TEXT DEFAULT (datetime('now'))
+    );
+  `);
+
+  // Journey milestones for guided compliance journey
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS journey_milestones (
+      milestone_id       INTEGER PRIMARY KEY,
+      name               TEXT NOT NULL,
+      status             TEXT DEFAULT 'LOCKED',
+      started_at         TEXT,
+      completed_at       TEXT,
+      evidence_count     INTEGER DEFAULT 0,
+      needs_revalidation INTEGER DEFAULT 0
+    );
+  `);
 }
 
 function init() {
@@ -349,19 +554,163 @@ function status() {
 }
 
 function controlDetail() {
-  const oscalId = args[1];
-  if (!oscalId) { console.error('Usage: comply-db control <oscal_id>'); process.exit(1); }
+  const inputId = args[1];
+  if (!inputId) { console.error('Usage: comply-db control <oscal_id|cfr_section> [--json] [--simple]'); process.exit(1); }
 
-  const db = openDb();
+  const jsonMode = args.includes('--json');
+  const simpleMode = args.includes('--simple');
+
+  // CFR resolution: if input looks like a HIPAA CFR section, resolve to NIST control IDs
+  let controlIds: string[];
+  let resolvedFrom: string | null = null;
+  if (isCFRSection(inputId)) {
+    controlIds = resolveFromCFR(inputId);
+    if (controlIds.length === 0) {
+      console.error(`CFR section ${inputId} not found in hipaa-filter.json.`);
+      process.exit(1);
+    }
+    resolvedFrom = inputId;
+  } else {
+    controlIds = [inputId];
+  }
+
+  // If multiple controls resolved from CFR, output each
+  if (jsonMode && controlIds.length > 1) {
+    const results = controlIds.map(id => buildControlData(id, resolvedFrom, simpleMode));
+    console.log(JSON.stringify(results, null, 2));
+    return;
+  }
+
+  // Single control (or first from CFR resolution for text mode)
+  const oscalId = controlIds[0];
+
+  if (jsonMode) {
+    const data = buildControlData(oscalId, resolvedFrom, simpleMode);
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    printControlText(oscalId);
+  }
+}
+
+/** Build enriched data object for a single control */
+function buildControlData(oscalId: string, resolvedFrom: string | null, simpleMode: boolean): any {
+  const dbPath = getDbPath();
+  const sources: Record<string, string> = {};
+
+  // Load NIST catalog (required)
+  const catalog = loadNistCatalog();
+  sources.nist_catalog = 'found';
+  const catalogIndex = buildCatalogIndex(catalog);
+
+  // Extract from catalog
+  const { prose, assess, title, family } = extractControlProse(catalog, oscalId);
+  const guidance = extractGuidance(catalog, oscalId);
+  const relatedControls = extractRelatedControls(catalog, oscalId, catalogIndex);
+
+  // Plain-English
+  const pe = loadPlainEnglish(oscalId);
+  sources.plain_english = pe ? 'found' : 'not_found';
+
+  // HIPAA sections (reverse-map: NIST → CFR)
+  let hipaaSections: string[] = [];
+  try {
+    const filterPath = path.join(NIST_DIR, 'hipaa-filter.json');
+    if (fs.existsSync(filterPath)) {
+      const filter = JSON.parse(fs.readFileSync(filterPath, 'utf-8'));
+      const upperControlId = oscalId.toUpperCase();
+      for (const [spec, controls] of Object.entries(filter.mapping)) {
+        if ((controls as string[]).some(c => c.toUpperCase() === upperControlId)) {
+          hipaaSections.push(spec);
+        }
+      }
+      sources.hipaa_filter = 'found';
+    } else {
+      sources.hipaa_filter = 'not_found';
+    }
+  } catch { sources.hipaa_filter = 'error'; }
+
+  // HIPAA name (from checklist, which is more complete than requirements)
+  const hipaaName = getHipaaName(hipaaSections);
+
+  // Verification normalization
+  const verification = normalizeVerification(oscalId);
+  sources.tool_bindings = verification !== null ? 'found' : 'not_found';
+
+  // SQLite-dependent fields
+  let status = 'unknown';
+  let evidenceCount = 0;
+  let detectedStack: string[] = [];
+  try {
+    if (fs.existsSync(dbPath)) {
+      const db = new Database(dbPath, { readonly: true });
+      const ctrl = db.prepare('SELECT status FROM controls WHERE oscal_id = ?').get(oscalId) as any;
+      if (ctrl) status = ctrl.status;
+      const evCount = db.prepare('SELECT COUNT(*) as cnt FROM evidence WHERE control_id = ?').get(oscalId) as any;
+      if (evCount) evidenceCount = evCount.cnt;
+      db.close();
+      sources.sqlite_db = 'found';
+    } else {
+      sources.sqlite_db = 'not_found';
+    }
+  } catch { sources.sqlite_db = 'error'; }
+
+  detectedStack = getDetectedStack(dbPath);
+
+  return {
+    control_id: oscalId,
+    resolved_from: resolvedFrom,
+    nist_name: title,
+    family,
+    plain_english: pe?.plain_english ?? null,
+    why_it_matters: pe?.why_it_matters ?? null,
+    nist_guidance: guidance || null,
+    hipaa_sections: hipaaSections,
+    hipaa_name: hipaaName,
+    related_controls: relatedControls,
+    status,
+    evidence_count: evidenceCount,
+    detected_stack: detectedStack,
+    verification,
+    eli5_requested: simpleMode,
+    _sources: sources,
+  };
+}
+
+/** Original text output for comply-db control (backwards compatible) */
+function printControlText(oscalId: string) {
+  const dbPath = getDbPath();
+  if (!fs.existsSync(dbPath)) {
+    console.error('No database. Run: comply-db init');
+    process.exit(1);
+  }
+
+  const db = new Database(dbPath, { readonly: true });
   const ctrl = db.prepare('SELECT * FROM controls WHERE oscal_id = ?').get(oscalId) as any;
-  if (!ctrl) { console.error(`Control ${oscalId} not found`); process.exit(1); }
+  if (!ctrl) {
+    // Show valid IDs
+    const all = db.prepare('SELECT oscal_id FROM controls ORDER BY oscal_id').all() as any[];
+    db.close();
+    const ids = all.map((r: any) => r.oscal_id);
+    const preview = ids.slice(0, 10).join(', ');
+    console.error(`Control ${oscalId} not found. Valid IDs (${ids.length} total): ${preview}${ids.length > 10 ? '...' : ''}`);
+    process.exit(1);
+  }
 
   const checks = db.prepare('SELECT * FROM check_results WHERE control_id = ? ORDER BY created_at DESC').all(oscalId) as any[];
   const evidence = db.prepare('SELECT * FROM evidence WHERE control_id = ? ORDER BY created_at DESC').all(oscalId) as any[];
   const sigs = db.prepare('SELECT * FROM signatures WHERE control_id = ? ORDER BY created_at DESC').all(oscalId) as any[];
 
+  // Plain-English header
+  const pe = loadPlainEnglish(oscalId);
+
   console.log(`\n═══ ${ctrl.oscal_id}: ${ctrl.title} ═══`);
   console.log(`Family: ${ctrl.family} | Status: ${ctrl.status}`);
+
+  if (pe) {
+    console.log(`\nPlain English: ${pe.plain_english}`);
+    console.log(`Why it matters: ${pe.why_it_matters}`);
+  }
+
   const refs = JSON.parse(ctrl.framework_refs || '{}');
   const refSummary = Object.entries(refs).map(([fw, specs]) => `${fw}: ${(specs as string[]).join(', ')}`).join(' | ');
   console.log(`Frameworks: ${refSummary}`);
@@ -1011,6 +1360,156 @@ function auditDiff() {
   console.log(JSON.stringify(result));
 }
 
+// ─── Journey ───────────────────────────────────────────────
+
+const JOURNEY_MILESTONES = [
+  { id: 1, name: 'Framework Advisor' },
+  { id: 2, name: 'Assessment & Scan' },
+  { id: 3, name: 'Policy Generator' },
+  { id: 4, name: 'PR Gate Setup' },
+  { id: 5, name: 'Trust Page' },
+  { id: 6, name: 'Deal Rescue' },
+];
+
+function journey() {
+  const sub = args[1];
+  if (!sub || !['init', 'status', 'skip', 'complete'].includes(sub)) {
+    console.error('Usage: comply-db journey <init|status|skip|complete> [--milestone N]');
+    process.exit(1);
+  }
+
+  const db = openDb();
+  migrateSchema(db);
+
+  if (sub === 'init') {
+    const existing = db.prepare('SELECT COUNT(*) as n FROM journey_milestones').get() as any;
+    if (existing.n > 0) {
+      console.log(JSON.stringify({ action: 'already_initialized', milestones: existing.n }));
+      return;
+    }
+    const insert = db.prepare('INSERT INTO journey_milestones (milestone_id, name, status) VALUES (?, ?, ?)');
+    const tx = db.transaction(() => {
+      for (const m of JOURNEY_MILESTONES) {
+        insert.run(m.id, m.name, m.id === 1 ? 'AVAILABLE' : 'LOCKED');
+      }
+    });
+    tx();
+    console.log(JSON.stringify({ action: 'initialized', milestones: JOURNEY_MILESTONES.length }));
+  }
+
+  if (sub === 'status') {
+    const milestones = db.prepare('SELECT * FROM journey_milestones ORDER BY milestone_id').all();
+    if (milestones.length === 0) {
+      console.log(JSON.stringify({ initialized: false, milestones: [] }));
+      return;
+    }
+    const current = (milestones as any[]).find(m => m.status !== 'COMPLETE') || null;
+    console.log(JSON.stringify({
+      initialized: true,
+      current_milestone: current ? { id: current.milestone_id, name: current.name, status: current.status } : null,
+      milestones: (milestones as any[]).map(m => ({
+        id: m.milestone_id,
+        name: m.name,
+        status: m.status,
+        needs_revalidation: !!m.needs_revalidation,
+      })),
+      complete: (milestones as any[]).every(m => m.status === 'COMPLETE'),
+    }));
+  }
+
+  if (sub === 'skip' || sub === 'complete') {
+    const milestoneId = Number(getFlag('milestone'));
+    if (!milestoneId || milestoneId < 1 || milestoneId > JOURNEY_MILESTONES.length) {
+      console.error(`Usage: comply-db journey ${sub} --milestone <1-${JOURNEY_MILESTONES.length}>`);
+      process.exit(1);
+    }
+    const label = sub === 'skip' ? 'COMPLETE' : 'COMPLETE';
+    const now = new Date().toISOString();
+    db.prepare('UPDATE journey_milestones SET status = ?, completed_at = ? WHERE milestone_id = ?')
+      .run(label, now, milestoneId);
+
+    // Unlock next milestone if it exists and is LOCKED
+    const nextId = milestoneId + 1;
+    if (nextId <= JOURNEY_MILESTONES.length) {
+      const next = db.prepare('SELECT status FROM journey_milestones WHERE milestone_id = ?').get(nextId) as any;
+      if (next && next.status === 'LOCKED') {
+        db.prepare('UPDATE journey_milestones SET status = ? WHERE milestone_id = ?').run('AVAILABLE', nextId);
+      }
+    }
+
+    console.log(JSON.stringify({
+      action: sub,
+      milestone_id: milestoneId,
+      status: label,
+      next_unlocked: nextId <= JOURNEY_MILESTONES.length ? nextId : null,
+    }));
+  }
+}
+
+// ─── User Config ───────────────────────────────────────────
+
+function getUserConfigPath(): string {
+  return path.join(process.env.HOME ?? '', '.em-dash', 'config.json');
+}
+
+function readUserConfig(): Record<string, any> {
+  const p = getUserConfigPath();
+  if (!fs.existsSync(p)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeUserConfig(config: Record<string, any>) {
+  const p = getUserConfigPath();
+  const dir = path.dirname(p);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(config, null, 2) + '\n');
+}
+
+function config() {
+  const sub = args[1];
+  const key = args[2];
+
+  if (sub === 'get') {
+    if (!key) {
+      // Return all config
+      console.log(JSON.stringify(readUserConfig()));
+      return;
+    }
+    const cfg = readUserConfig();
+    console.log(cfg[key] ?? '');
+    return;
+  }
+
+  if (sub === 'set') {
+    const value = args[3];
+    if (!key || value === undefined) {
+      console.error('Usage: comply-db config set <key> <value>');
+      process.exit(1);
+    }
+    const validKeys: Record<string, string[]> = {
+      persona: ['founder', 'engineer', 'audit'],
+      explain: ['always', 'on-demand', 'off'],
+      auto_sign: ['true', 'false'],
+    };
+    if (validKeys[key] && !validKeys[key].includes(value)) {
+      console.error(`Invalid value for ${key}. Must be one of: ${validKeys[key].join(', ')}`);
+      process.exit(1);
+    }
+    const cfg = readUserConfig();
+    cfg[key] = value;
+    writeUserConfig(cfg);
+    console.log(JSON.stringify({ action: 'set', key, value }));
+    return;
+  }
+
+  console.error('Usage: comply-db config <get|set> <key> [value]');
+  process.exit(1);
+}
+
 // ─── Router ─────────────────────────────────────────────────
 
 switch (subcommand) {
@@ -1029,9 +1528,11 @@ switch (subcommand) {
   case 'record-finding': recordAuditFinding(); break;
   case 'record-response': recordFindingResponse(); break;
   case 'audit-diff': auditDiff(); break;
+  case 'journey': journey(); break;
+  case 'config': config(); break;
   case 'query': rawQuery(); break;
   default:
-    console.error('Usage: comply-db <init|status|control|update-scan|summary|cross-framework|frameworks|hipaa-sections|audit-snapshot|record-finding|record-response|audit-diff|cis-coverage|query>');
+    console.error('Usage: comply-db <init|status|control|update-scan|summary|cross-framework|frameworks|hipaa-sections|audit-snapshot|record-finding|record-response|audit-diff|cis-coverage|journey|config|query>');
     if (subcommand) console.error(`Unknown: ${subcommand}`);
     process.exit(1);
 }

--- a/bin/comply-db
+++ b/bin/comply-db
@@ -62,12 +62,16 @@ function getSlug(): string {
 }
 
 function getDbPath(): string {
-  const dir = path.join(process.env.HOME ?? '', '.em-dash', 'projects', getSlug());
+  return path.join(process.env.HOME ?? '', '.em-dash', 'projects', getSlug(), 'compliance.db');
+}
+
+function ensureDbDir(): void {
+  const dir = path.dirname(getDbPath());
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  return path.join(dir, 'compliance.db');
 }
 
 function openDb(): InstanceType<typeof Database> {
+  ensureDbDir();
   return new Database(getDbPath());
 }
 
@@ -83,27 +87,28 @@ function loadFilter(): any {
   return JSON.parse(fs.readFileSync(p, 'utf-8'));
 }
 
-/** Extract control prose from NIST catalog */
-function extractControlProse(catalog: any, controlId: string): { prose: string; assess: string; title: string; family: string } {
+/** Find a control object in the NIST catalog by ID. Returns the control and its family group. */
+function findControlInCatalog(catalog: any, controlId: string): { control: any; family: string } | null {
   const id = controlId.toLowerCase();
   for (const group of catalog.catalog.groups) {
     for (const ctrl of group.controls || []) {
-      if (ctrl.id === id) {
-        const prose = extractParts(ctrl.parts?.filter((p: any) => p.name === 'statement') || []);
-        const assess = extractParts(ctrl.parts?.filter((p: any) => p.name === 'assessment') || []);
-        return { prose, assess, title: ctrl.title, family: group.title };
-      }
-      // Check enhancements
+      if (ctrl.id === id) return { control: ctrl, family: group.title };
       for (const enh of ctrl.controls || []) {
-        if (enh.id === id) {
-          const prose = extractParts(enh.parts?.filter((p: any) => p.name === 'statement') || []);
-          const assess = extractParts(enh.parts?.filter((p: any) => p.name === 'assessment') || []);
-          return { prose, assess, title: enh.title || ctrl.title, family: group.title };
-        }
+        if (enh.id === id) return { control: enh, family: group.title };
       }
     }
   }
-  return { prose: '', assess: '', title: controlId, family: 'Unknown' };
+  return null;
+}
+
+/** Extract control prose from NIST catalog */
+function extractControlProse(catalog: any, controlId: string): { prose: string; assess: string; title: string; family: string } {
+  const found = findControlInCatalog(catalog, controlId);
+  if (!found) return { prose: '', assess: '', title: controlId, family: 'Unknown' };
+  const { control, family } = found;
+  const prose = extractParts(control.parts?.filter((p: any) => p.name === 'statement') || []);
+  const assess = extractParts(control.parts?.filter((p: any) => p.name === 'assessment') || []);
+  return { prose, assess, title: control.title, family };
 }
 
 function extractParts(parts: any[]): string {
@@ -133,22 +138,10 @@ function loadPlainEnglish(controlId: string): { plain_english: string; why_it_ma
 }
 
 function extractGuidance(catalog: any, controlId: string): string {
-  const id = controlId.toLowerCase();
-  for (const group of catalog.catalog.groups) {
-    for (const ctrl of group.controls || []) {
-      if (ctrl.id === id) {
-        const guidancePart = ctrl.parts?.find((p: any) => p.name === 'guidance');
-        return guidancePart?.prose || '';
-      }
-      for (const enh of ctrl.controls || []) {
-        if (enh.id === id) {
-          const guidancePart = enh.parts?.find((p: any) => p.name === 'guidance');
-          return guidancePart?.prose || '';
-        }
-      }
-    }
-  }
-  return '';
+  const found = findControlInCatalog(catalog, controlId);
+  if (!found) return '';
+  const guidancePart = found.control.parts?.find((p: any) => p.name === 'guidance');
+  return guidancePart?.prose || '';
 }
 
 /** Build an index of controlId → title from the full NIST catalog */
@@ -166,30 +159,14 @@ function buildCatalogIndex(catalog: any): Record<string, string> {
 }
 
 function extractRelatedControls(catalog: any, controlId: string, catalogIndex: Record<string, string>): { id: string; title: string }[] {
-  const id = controlId.toLowerCase();
-  for (const group of catalog.catalog.groups) {
-    for (const ctrl of group.controls || []) {
-      if (ctrl.id === id) {
-        return (ctrl.links || [])
-          .filter((l: any) => l.rel === 'related')
-          .map((l: any) => {
-            const refId = l.href.replace('#', '').toUpperCase();
-            return { id: refId, title: catalogIndex[refId] || refId };
-          });
-      }
-      for (const enh of ctrl.controls || []) {
-        if (enh.id === id) {
-          return (enh.links || [])
-            .filter((l: any) => l.rel === 'related')
-            .map((l: any) => {
-              const refId = l.href.replace('#', '').toUpperCase();
-              return { id: refId, title: catalogIndex[refId] || refId };
-            });
-        }
-      }
-    }
-  }
-  return [];
+  const found = findControlInCatalog(catalog, controlId);
+  if (!found) return [];
+  return (found.control.links || [])
+    .filter((l: any) => l.rel === 'related')
+    .map((l: any) => {
+      const refId = l.href.replace('#', '').toUpperCase();
+      return { id: refId, title: catalogIndex[refId] || refId };
+    });
 }
 
 function resolveFromCFR(cfrSection: string): string[] {
@@ -244,22 +221,6 @@ function getHipaaName(cfrSections: string[]): string | null {
     }
     return null;
   } catch { return null; }
-}
-
-function getDetectedStack(dbPath: string): string[] {
-  try {
-    if (!fs.existsSync(dbPath)) return [];
-    const db = new Database(dbPath, { readonly: true });
-    // vendor_registry is created by comply-start apply, not by comply-db init
-    try {
-      const vendors = db.prepare('SELECT vendor FROM vendor_registry').all() as any[];
-      db.close();
-      return vendors.map((v: any) => v.vendor).filter(Boolean);
-    } catch {
-      db.close();
-      return [];
-    }
-  } catch { return []; }
 }
 
 /** Check if input looks like a HIPAA CFR section (e.g., 164.312(a)(2)(iv)) */
@@ -594,6 +555,9 @@ function controlDetail() {
 
 /** Build enriched data object for a single control */
 function buildControlData(oscalId: string, resolvedFrom: string | null, simpleMode: boolean): any {
+  // Normalize to uppercase for consistent lookups across data files
+  oscalId = oscalId.toUpperCase();
+
   const dbPath = getDbPath();
   const sources: Record<string, string> = {};
 
@@ -601,6 +565,12 @@ function buildControlData(oscalId: string, resolvedFrom: string | null, simpleMo
   const catalog = loadNistCatalog();
   sources.nist_catalog = 'found';
   const catalogIndex = buildCatalogIndex(catalog);
+
+  // Validate control exists in catalog
+  if (!findControlInCatalog(catalog, oscalId)) {
+    console.error(`Control ${oscalId} not found in NIST catalog.`);
+    process.exit(1);
+  }
 
   // Extract from catalog
   const { prose, assess, title, family } = extractControlProse(catalog, oscalId);
@@ -617,9 +587,8 @@ function buildControlData(oscalId: string, resolvedFrom: string | null, simpleMo
     const filterPath = path.join(NIST_DIR, 'hipaa-filter.json');
     if (fs.existsSync(filterPath)) {
       const filter = JSON.parse(fs.readFileSync(filterPath, 'utf-8'));
-      const upperControlId = oscalId.toUpperCase();
       for (const [spec, controls] of Object.entries(filter.mapping)) {
-        if ((controls as string[]).some(c => c.toUpperCase() === upperControlId)) {
+        if ((controls as string[]).some(c => c.toUpperCase() === oscalId)) {
           hipaaSections.push(spec);
         }
       }
@@ -636,7 +605,7 @@ function buildControlData(oscalId: string, resolvedFrom: string | null, simpleMo
   const verification = normalizeVerification(oscalId);
   sources.tool_bindings = verification !== null ? 'found' : 'not_found';
 
-  // SQLite-dependent fields
+  // SQLite-dependent fields (single DB connection)
   let status = 'unknown';
   let evidenceCount = 0;
   let detectedStack: string[] = [];
@@ -647,14 +616,17 @@ function buildControlData(oscalId: string, resolvedFrom: string | null, simpleMo
       if (ctrl) status = ctrl.status;
       const evCount = db.prepare('SELECT COUNT(*) as cnt FROM evidence WHERE control_id = ?').get(oscalId) as any;
       if (evCount) evidenceCount = evCount.cnt;
+      // Read vendor_registry in the same connection
+      try {
+        const vendors = db.prepare('SELECT vendor FROM vendor_registry').all() as any[];
+        detectedStack = vendors.map((v: any) => v.vendor).filter(Boolean);
+      } catch { /* vendor_registry may not exist yet */ }
       db.close();
       sources.sqlite_db = 'found';
     } else {
       sources.sqlite_db = 'not_found';
     }
   } catch { sources.sqlite_db = 'error'; }
-
-  detectedStack = getDetectedStack(dbPath);
 
   return {
     control_id: oscalId,
@@ -1384,6 +1356,7 @@ function journey() {
   if (sub === 'init') {
     const existing = db.prepare('SELECT COUNT(*) as n FROM journey_milestones').get() as any;
     if (existing.n > 0) {
+      db.close();
       console.log(JSON.stringify({ action: 'already_initialized', milestones: existing.n }));
       return;
     }
@@ -1394,16 +1367,19 @@ function journey() {
       }
     });
     tx();
+    db.close();
     console.log(JSON.stringify({ action: 'initialized', milestones: JOURNEY_MILESTONES.length }));
+    return;
   }
 
   if (sub === 'status') {
     const milestones = db.prepare('SELECT * FROM journey_milestones ORDER BY milestone_id').all();
     if (milestones.length === 0) {
+      db.close();
       console.log(JSON.stringify({ initialized: false, milestones: [] }));
       return;
     }
-    const current = (milestones as any[]).find(m => m.status !== 'COMPLETE') || null;
+    const current = (milestones as any[]).find(m => m.status !== 'COMPLETE' && m.status !== 'SKIPPED') || null;
     console.log(JSON.stringify({
       initialized: true,
       current_milestone: current ? { id: current.milestone_id, name: current.name, status: current.status } : null,
@@ -1413,8 +1389,10 @@ function journey() {
         status: m.status,
         needs_revalidation: !!m.needs_revalidation,
       })),
-      complete: (milestones as any[]).every(m => m.status === 'COMPLETE'),
+      complete: (milestones as any[]).every(m => m.status === 'COMPLETE' || m.status === 'SKIPPED'),
     }));
+    db.close();
+    return;
   }
 
   if (sub === 'skip' || sub === 'complete') {
@@ -1423,7 +1401,7 @@ function journey() {
       console.error(`Usage: comply-db journey ${sub} --milestone <1-${JOURNEY_MILESTONES.length}>`);
       process.exit(1);
     }
-    const label = sub === 'skip' ? 'COMPLETE' : 'COMPLETE';
+    const label = sub === 'skip' ? 'SKIPPED' : 'COMPLETE';
     const now = new Date().toISOString();
     db.prepare('UPDATE journey_milestones SET status = ?, completed_at = ? WHERE milestone_id = ?')
       .run(label, now, milestoneId);
@@ -1437,6 +1415,7 @@ function journey() {
       }
     }
 
+    db.close();
     console.log(JSON.stringify({
       action: sub,
       milestone_id: milestoneId,
@@ -1495,7 +1474,11 @@ function config() {
       explain: ['always', 'on-demand', 'off'],
       auto_sign: ['true', 'false'],
     };
-    if (validKeys[key] && !validKeys[key].includes(value)) {
+    if (!Object.keys(validKeys).includes(key)) {
+      console.error(`Unknown config key: ${key}. Known keys: ${Object.keys(validKeys).join(', ')}`);
+      process.exit(1);
+    }
+    if (!validKeys[key].includes(value)) {
       console.error(`Invalid value for ${key}. Must be one of: ${validKeys[key].join(', ')}`);
       process.exit(1);
     }

--- a/nist/baa-vendors.json
+++ b/nist/baa-vendors.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0.0",
+  "description": "Curated list of services that may require Business Associate Agreements for HIPAA compliance",
+  "vendors": [
+    {"name": "segment", "packages": ["analytics-node", "@segment/analytics-next", "@segment/analytics-node"], "baa_required": true},
+    {"name": "twilio", "packages": ["twilio"], "baa_required": true},
+    {"name": "sendgrid", "packages": ["@sendgrid/mail", "@sendgrid/client"], "baa_required": true},
+    {"name": "stripe", "packages": ["stripe", "@stripe/stripe-js"], "baa_required": false, "note": "BAA available on request for healthcare use cases"},
+    {"name": "mixpanel", "packages": ["mixpanel", "mixpanel-browser"], "baa_required": true},
+    {"name": "intercom", "packages": ["intercom-client"], "baa_required": true},
+    {"name": "zendesk", "packages": ["zendesk-node-sdk", "node-zendesk"], "baa_required": true},
+    {"name": "hubspot", "packages": ["@hubspot/api-client"], "baa_required": true},
+    {"name": "mailchimp", "packages": ["@mailchimp/mailchimp_marketing", "@mailchimp/mailchimp_transactional"], "baa_required": true},
+    {"name": "datadog", "packages": ["dd-trace", "datadog-metrics"], "baa_required": true},
+    {"name": "sentry", "packages": ["@sentry/node", "@sentry/browser", "@sentry/react"], "baa_required": true},
+    {"name": "fullstory", "packages": ["@fullstory/browser"], "baa_required": true},
+    {"name": "amplitude", "packages": ["@amplitude/analytics-node", "@amplitude/analytics-browser"], "baa_required": true}
+  ]
+}

--- a/nist/plain-english.json
+++ b/nist/plain-english.json
@@ -1,0 +1,297 @@
+{
+  "AC-1": {
+    "nist_name": "Policy and Procedures",
+    "plain_english": "Write down your rules for who can access patient data and how, and make sure everyone on your team has read them.",
+    "why_it_matters": "Without written rules, every employee makes up their own, and you have no defense in a breach investigation."
+  },
+  "AC-2": {
+    "nist_name": "Account Management",
+    "plain_english": "Give every person who touches patient data their own unique login, and remove access the same day someone leaves.",
+    "why_it_matters": "If everyone shares one login, you cannot tell who accessed what when something goes wrong."
+  },
+  "AC-3": {
+    "nist_name": "Access Enforcement",
+    "plain_english": "Set up your systems so people can only see the patient data they actually need for their job.",
+    "why_it_matters": "A billing clerk who can read therapy notes is a lawsuit waiting to happen."
+  },
+  "AC-4": {
+    "nist_name": "Information Flow Enforcement",
+    "plain_english": "Control how patient data moves between your systems so it cannot flow to places it should not be.",
+    "why_it_matters": "Uncontrolled data flow means patient records can end up in test environments, analytics tools, or third-party apps without anyone noticing."
+  },
+  "AC-5": {
+    "nist_name": "Separation of Duties",
+    "plain_english": "Make sure no single person can both grant access to patient data and use that access themselves.",
+    "why_it_matters": "When one person controls everything, mistakes and misuse go undetected."
+  },
+  "AC-6": {
+    "nist_name": "Least Privilege",
+    "plain_english": "Give each person the minimum level of access they need to do their job, and nothing more.",
+    "why_it_matters": "The more access someone has, the more damage they can do, whether by accident or on purpose."
+  },
+  "AC-7": {
+    "nist_name": "Unsuccessful Logon Attempts",
+    "plain_english": "Lock accounts automatically after a few failed password attempts.",
+    "why_it_matters": "Without lockouts, attackers can try thousands of passwords until they break in."
+  },
+  "AC-11": {
+    "nist_name": "Device Lock",
+    "plain_english": "Set all computers and devices to lock their screens automatically after a short period of inactivity.",
+    "why_it_matters": "An unlocked screen in a clinic or coffee shop is an open door to every patient record on that device."
+  },
+  "AT-2": {
+    "nist_name": "Literacy Training and Awareness",
+    "plain_english": "Train every employee on how to spot phishing emails, handle patient data safely, and report security problems.",
+    "why_it_matters": "Most breaches start with a human mistake, and training is the cheapest way to prevent them."
+  },
+  "AU-2": {
+    "nist_name": "Event Logging",
+    "plain_english": "Decide which events your systems must log, like logins, data access, and configuration changes, and turn on logging for all of them.",
+    "why_it_matters": "If you do not log events, you will not know a breach happened until a patient or regulator tells you."
+  },
+  "AU-3": {
+    "nist_name": "Content of Audit Records",
+    "plain_english": "Make sure every log entry records who did what, when they did it, and which patient data was involved.",
+    "why_it_matters": "Incomplete logs are as useless as no logs when investigators ask you to reconstruct what happened."
+  },
+  "AU-6": {
+    "nist_name": "Audit Record Review, Analysis, and Reporting",
+    "plain_english": "Assign someone to regularly review your logs and investigate anything suspicious.",
+    "why_it_matters": "Logs that nobody reads are just wasted disk space; the average breach goes undetected for months without active review."
+  },
+  "AU-11": {
+    "nist_name": "Audit Record Retention",
+    "plain_english": "Keep your access logs for at least six years, stored safely where they cannot be tampered with.",
+    "why_it_matters": "HIPAA requires six-year document retention, and deleted logs look like you are hiding something."
+  },
+  "AU-12": {
+    "nist_name": "Audit Record Generation",
+    "plain_english": "Configure every system that handles patient data to automatically generate log entries for security-relevant events.",
+    "why_it_matters": "Systems that do not generate logs create blind spots where breaches can happen without any trace."
+  },
+  "CA-2": {
+    "nist_name": "Control Assessments",
+    "plain_english": "Test your security controls at least once a year to make sure they actually work the way you think they do.",
+    "why_it_matters": "Controls that are not tested regularly tend to break silently, leaving you exposed without knowing it."
+  },
+  "CA-7": {
+    "nist_name": "Continuous Monitoring",
+    "plain_english": "Set up automated tools that continuously watch your systems for security problems and alert you in real time.",
+    "why_it_matters": "Annual audits catch problems a year too late; continuous monitoring catches them while you can still fix them."
+  },
+  "CM-8": {
+    "nist_name": "System Component Inventory",
+    "plain_english": "Keep an up-to-date list of every server, database, laptop, and application that stores or processes patient data.",
+    "why_it_matters": "You cannot protect what you do not know exists, and forgotten systems are the easiest targets for attackers."
+  },
+  "CP-1": {
+    "nist_name": "Policy and Procedures",
+    "plain_english": "Write a plan for how your company will keep running if your systems go down, and make sure everyone knows where to find it.",
+    "why_it_matters": "Without a written plan, a server crash or ransomware attack turns into chaos that puts patient care at risk."
+  },
+  "CP-2": {
+    "nist_name": "Contingency Plan",
+    "plain_english": "Create a step-by-step emergency plan that covers who does what, how to recover data, and how to keep serving patients if your main systems fail.",
+    "why_it_matters": "When systems go down, every minute of confusion is a minute patients cannot get the care they need."
+  },
+  "CP-4": {
+    "nist_name": "Contingency Plan Testing",
+    "plain_english": "Test your emergency recovery plan at least once a year by actually running through it, not just reading it.",
+    "why_it_matters": "A plan that has never been tested will almost certainly fail when you need it most."
+  },
+  "CP-9": {
+    "nist_name": "System Backup",
+    "plain_english": "Back up all patient data regularly, store backups in a separate location, and verify you can actually restore from them.",
+    "why_it_matters": "Ransomware or hardware failure without working backups means permanent loss of patient records."
+  },
+  "CP-10": {
+    "nist_name": "System Recovery and Reconstitution",
+    "plain_english": "Have a tested process to rebuild your systems and restore patient data to a known good state after an outage or attack.",
+    "why_it_matters": "Getting back online fast after an incident is the difference between a bad day and a business-ending event."
+  },
+  "IA-2": {
+    "nist_name": "Identification and Authentication (Organizational Users)",
+    "plain_english": "Require everyone to prove who they are before accessing any system with patient data, using strong authentication like multi-factor login.",
+    "why_it_matters": "A password alone is not enough; stolen passwords are the number one way attackers get into healthcare systems."
+  },
+  "IA-4": {
+    "nist_name": "Identifier Management",
+    "plain_english": "Assign a unique user ID to every person and make sure no two people ever share the same login credentials.",
+    "why_it_matters": "Shared IDs make it impossible to track who accessed a patient record, which is exactly what regulators will ask."
+  },
+  "IA-5": {
+    "nist_name": "Authenticator Management",
+    "plain_english": "Set strong password rules, require regular password changes, and never store passwords in plain text.",
+    "why_it_matters": "Weak or reused passwords are the easiest way for attackers to break into your systems and steal patient data."
+  },
+  "IR-1": {
+    "nist_name": "Policy and Procedures",
+    "plain_english": "Write a clear incident response plan that spells out what to do, who to call, and how to report a security incident.",
+    "why_it_matters": "HIPAA requires you to report breaches within 60 days, and you cannot meet that deadline if you are figuring out the process on the fly."
+  },
+  "IR-4": {
+    "nist_name": "Incident Handling",
+    "plain_english": "When a security incident happens, follow a defined process to contain the damage, investigate the cause, and fix the problem.",
+    "why_it_matters": "An uncontained breach spreads fast and turns a small incident into a front-page disaster."
+  },
+  "IR-5": {
+    "nist_name": "Incident Monitoring",
+    "plain_english": "Track and document every security incident, no matter how small, so you can spot patterns and prevent repeat problems.",
+    "why_it_matters": "Small incidents that go untracked often turn out to be early warning signs of a major breach."
+  },
+  "IR-6": {
+    "nist_name": "Incident Reporting",
+    "plain_english": "Report security incidents to the right people inside your company and to outside authorities when required by law.",
+    "why_it_matters": "Failing to report a breach to HHS on time can turn a manageable fine into a million-dollar penalty."
+  },
+  "MA-2": {
+    "nist_name": "Controlled Maintenance",
+    "plain_english": "Schedule and document all maintenance on systems that handle patient data, and make sure maintenance does not expose that data.",
+    "why_it_matters": "Unplanned maintenance by unvetted people is a common way patient data gets exposed or systems get compromised."
+  },
+  "MA-5": {
+    "nist_name": "Maintenance Personnel",
+    "plain_english": "Vet anyone who performs maintenance on your systems and supervise them if they are not your own employees.",
+    "why_it_matters": "A repair technician with unsupervised access to your servers has the same access as your most trusted admin."
+  },
+  "MP-1": {
+    "nist_name": "Policy and Procedures",
+    "plain_english": "Write rules for how physical media like hard drives, USB sticks, and paper records containing patient data must be handled and stored.",
+    "why_it_matters": "A lost USB drive with unencrypted patient data is a reportable breach, even if nobody ever reads it."
+  },
+  "MP-2": {
+    "nist_name": "Media Access",
+    "plain_english": "Limit who can physically access storage media that contains patient data, and keep it locked up when not in use.",
+    "why_it_matters": "An unlocked filing cabinet or an unattended external drive is just as dangerous as an unlocked database."
+  },
+  "MP-6": {
+    "nist_name": "Media Sanitization",
+    "plain_english": "Before disposing of or reusing any device or disk that held patient data, wipe it completely so the data cannot be recovered.",
+    "why_it_matters": "Old hard drives sold on eBay with recoverable patient records have led to some of the most embarrassing HIPAA fines."
+  },
+  "PE-1": {
+    "nist_name": "Policy and Procedures",
+    "plain_english": "Write rules for who can physically enter areas where patient data is stored or processed, like server rooms and offices.",
+    "why_it_matters": "Digital security is worthless if anyone can walk into your server room and plug in a USB drive."
+  },
+  "PE-2": {
+    "nist_name": "Physical Access Authorizations",
+    "plain_english": "Keep a list of exactly who is authorized to enter secure areas, and update it whenever someone joins, moves, or leaves.",
+    "why_it_matters": "Former employees who still have badge access are a real and common threat to patient data."
+  },
+  "PE-3": {
+    "nist_name": "Physical Access Control",
+    "plain_english": "Use locks, badge readers, or other controls to physically prevent unauthorized people from getting to systems with patient data.",
+    "why_it_matters": "The best firewall in the world does not help if someone can walk up to the server and pull the hard drive."
+  },
+  "PE-5": {
+    "nist_name": "Access Control for Output Devices",
+    "plain_english": "Place printers, fax machines, and monitors that display patient data in areas where only authorized people can see them.",
+    "why_it_matters": "Patient records left sitting on a shared printer in a hallway are a privacy violation that happens every day in healthcare."
+  },
+  "PL-1": {
+    "nist_name": "Policy and Procedures",
+    "plain_english": "Write and maintain a master security plan that documents all of your security policies, who is responsible for what, and when they get reviewed.",
+    "why_it_matters": "A complete, current security plan is the first thing auditors ask for, and not having one is an automatic finding."
+  },
+  "PL-4": {
+    "nist_name": "Rules of Behavior",
+    "plain_english": "Create an acceptable-use agreement that every employee signs, spelling out what they can and cannot do with patient data.",
+    "why_it_matters": "Without a signed agreement, you cannot hold employees accountable or discipline them for mishandling data."
+  },
+  "PM-1": {
+    "nist_name": "Information Security Program Plan",
+    "plain_english": "Build a company-wide security program with clear goals, assigned responsibilities, and a timeline for getting everything done.",
+    "why_it_matters": "Scattered, one-off security efforts leave gaps that attackers will find and exploit."
+  },
+  "PM-2": {
+    "nist_name": "Information Security Program Leadership Role",
+    "plain_english": "Appoint one specific person to be in charge of your security program and give them the authority and resources to do the job.",
+    "why_it_matters": "When security is everyone's job, it ends up being nobody's job, and things fall through the cracks."
+  },
+  "PM-9": {
+    "nist_name": "Risk Management Strategy",
+    "plain_english": "Define how your company identifies, evaluates, and responds to risks to patient data, and document it as a formal strategy.",
+    "why_it_matters": "Without a strategy, you will spend money on the wrong risks and miss the ones that actually threaten your patients."
+  },
+  "PS-1": {
+    "nist_name": "Policy and Procedures",
+    "plain_english": "Write rules covering how you screen, hire, manage, and terminate employees who will have access to patient data.",
+    "why_it_matters": "Insider threats cause a significant share of healthcare breaches, and good HR policies are your first line of defense."
+  },
+  "PS-2": {
+    "nist_name": "Position Risk Designation",
+    "plain_english": "Classify every job role by how much access to patient data it requires, and screen people accordingly before granting access.",
+    "why_it_matters": "Treating a database admin the same as a receptionist means either over-screening everyone or under-screening the people who matter most."
+  },
+  "PS-3": {
+    "nist_name": "Personnel Screening",
+    "plain_english": "Run background checks on anyone who will have access to patient data before giving them that access.",
+    "why_it_matters": "Skipping background checks means you might hand the keys to patient records to someone with a history of fraud or data theft."
+  },
+  "PS-4": {
+    "nist_name": "Personnel Termination",
+    "plain_english": "Immediately revoke all access to patient data and collect all company devices when an employee leaves or is fired.",
+    "why_it_matters": "A disgruntled former employee with active credentials is one of the most dangerous threats to your data."
+  },
+  "PS-8": {
+    "nist_name": "Personnel Sanctions",
+    "plain_english": "Have a clear, documented process for disciplining employees who violate your security or privacy policies.",
+    "why_it_matters": "If there are no consequences for breaking the rules, the rules do not mean anything."
+  },
+  "RA-2": {
+    "nist_name": "Security Categorization",
+    "plain_english": "Classify your systems by how sensitive the patient data they handle is, so you know which ones need the strongest protection.",
+    "why_it_matters": "If you treat every system the same, you will either overspend on low-risk systems or under-protect the ones that matter most."
+  },
+  "RA-3": {
+    "nist_name": "Risk Assessment",
+    "plain_english": "Regularly identify what could go wrong with your patient data, how likely it is, and how bad it would be, and write it all down.",
+    "why_it_matters": "HIPAA specifically requires a risk assessment, and not having one is the most common reason for enforcement action."
+  },
+  "RA-5": {
+    "nist_name": "Vulnerability Monitoring and Scanning",
+    "plain_english": "Scan your systems regularly for known security weaknesses and fix what you find on a schedule.",
+    "why_it_matters": "Attackers use automated tools to find unpatched systems; if you are not scanning, they will find your weaknesses before you do."
+  },
+  "SA-9": {
+    "nist_name": "External System Services",
+    "plain_english": "Vet every vendor and cloud service that touches patient data, get a signed Business Associate Agreement, and monitor their security.",
+    "why_it_matters": "You are legally responsible for your vendors' breaches if you did not do your due diligence and get a BAA."
+  },
+  "SC-2": {
+    "nist_name": "Separation of System and User Functionality",
+    "plain_english": "Keep your administrative tools and management functions separate from the parts of your system that regular users and patients interact with.",
+    "why_it_matters": "If admin functions are mixed with user-facing features, an attacker who compromises one gets access to everything."
+  },
+  "SC-8": {
+    "nist_name": "Transmission Confidentiality and Integrity",
+    "plain_english": "Encrypt all patient data whenever it is sent over a network, whether by email, API, or file transfer.",
+    "why_it_matters": "Unencrypted data in transit can be intercepted by anyone on the same network, including on public Wi-Fi."
+  },
+  "SC-13": {
+    "nist_name": "Cryptographic Protection",
+    "plain_english": "Use strong, industry-standard encryption algorithms for protecting patient data, and do not try to build your own.",
+    "why_it_matters": "Homemade or outdated encryption is the same as no encryption when a skilled attacker targets your data."
+  },
+  "SC-28": {
+    "nist_name": "Protection of Information at Rest",
+    "plain_english": "Encrypt patient data wherever it is stored, including databases, file systems, backups, and laptop hard drives.",
+    "why_it_matters": "A stolen laptop or breached database with encrypted data is an incident; without encryption, it is a reportable breach."
+  },
+  "SI-3": {
+    "nist_name": "Malicious Code Protection",
+    "plain_english": "Install and keep updated antivirus and anti-malware tools on every device that accesses patient data.",
+    "why_it_matters": "Ransomware targeting healthcare is surging, and outdated malware protection is like leaving your front door open."
+  },
+  "SI-7": {
+    "nist_name": "Software, Firmware, and Information Integrity",
+    "plain_english": "Use tools to detect unauthorized changes to your software, configurations, and patient data so you know if something has been tampered with.",
+    "why_it_matters": "If an attacker quietly changes your code or data and you cannot detect it, you may be serving corrupted records for months."
+  },
+  "SI-12": {
+    "nist_name": "Information Management and Retention",
+    "plain_english": "Only keep patient data as long as you legally need it, and securely destroy it when that time is up.",
+    "why_it_matters": "Data you no longer need but still store is just more fuel for a breach, with zero business benefit."
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "bun run gen:skill-docs",
     "gen:skill-docs": "bun run scripts/gen-skill-docs.ts",
-    "test": "bun test test/skill-validation.test.ts test/rego-policy.test.ts test/bin-smoke.test.ts test/touchfiles.test.ts test/architecture.test.ts",
+    "test": "bun test test/skill-validation.test.ts test/rego-policy.test.ts test/bin-smoke.test.ts test/touchfiles.test.ts test/architecture.test.ts test/plain-english.test.ts",
     "test:evals": "EVALS=1 bun test test/skill-e2e.test.ts",
     "test:evals:all": "EVALS_ALL=1 bun test test/skill-e2e.test.ts",
     "skill:check": "bun run scripts/skill-check.ts",

--- a/skills/comply-assess/SKILL.md
+++ b/skills/comply-assess/SKILL.md
@@ -55,13 +55,20 @@ Read this carefully. Your questions should be derived FROM the NIST text.
 
 ## Step 4: Ask questions ONE AT A TIME
 
+Before asking questions for a control, get the plain-English context:
+```bash
+"$_EMDASH_BIN"/comply-db control <OSCAL_ID> --json 2>/dev/null
+```
+If the output includes `why_it_matters`, include it as a one-liner under your question so the user understands WHY they're being asked.
+
 For each control, ask 1-3 questions via AskUserQuestion. Derive the questions from the NIST prose.
 
 **Format each question:**
-1. State the HIPAA requirement in plain English
-2. Reference the NIST control: "NIST AC-2 requires..."
-3. Ask the specific question
-4. Provide examples of good answers
+1. State the HIPAA requirement in plain English (use `plain_english` field if available)
+2. Include why it matters: the `why_it_matters` field explains the consequence
+3. Reference the NIST control: "NIST AC-2 requires..."
+4. Ask the specific question
+5. Provide examples of good answers
 
 **Smart-skip:** If the user's previous answer already covers this question, skip it.
 

--- a/skills/comply-assess/SKILL.md.tmpl
+++ b/skills/comply-assess/SKILL.md.tmpl
@@ -53,13 +53,20 @@ Read this carefully. Your questions should be derived FROM the NIST text.
 
 ## Step 4: Ask questions ONE AT A TIME
 
+Before asking questions for a control, get the plain-English context:
+```bash
+"$_EMDASH_BIN"/comply-db control <OSCAL_ID> --json 2>/dev/null
+```
+If the output includes `why_it_matters`, include it as a one-liner under your question so the user understands WHY they're being asked.
+
 For each control, ask 1-3 questions via AskUserQuestion. Derive the questions from the NIST prose.
 
 **Format each question:**
-1. State the HIPAA requirement in plain English
-2. Reference the NIST control: "NIST AC-2 requires..."
-3. Ask the specific question
-4. Provide examples of good answers
+1. State the HIPAA requirement in plain English (use `plain_english` field if available)
+2. Include why it matters: the `why_it_matters` field explains the consequence
+3. Reference the NIST control: "NIST AC-2 requires..."
+4. Ask the specific question
+5. Provide examples of good answers
 
 **Smart-skip:** If the user's previous answer already covers this question, skip it.
 

--- a/skills/comply-auto/SKILL.md
+++ b/skills/comply-auto/SKILL.md
@@ -1,18 +1,13 @@
 ---
 
 name: comply-auto
-version: 2.0.0
+version: 3.0.0
 description: |
-  HIPAA compliance autopilot. Loops through ALL controls: scans infrastructure,
-  fixes what it can, asks questions for interview-only controls. The "just
-  handle it" command.
+  DEPRECATED — comply-auto is now a mode within /comply.
+  Run /comply and select Autopilot mode for the same functionality.
+  This wrapper will be removed in a future version.
 allowed-tools:
   - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
   - AskUserQuestion
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
@@ -23,101 +18,14 @@ allowed-tools:
 > **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
 
 
-# /comply-auto — Compliance Autopilot
+# /comply-auto — Deprecated
 
-You are the autopilot. Loop through every NIST 800-53 control and handle it end-to-end.
+**This skill has been absorbed into `/comply` as Autopilot mode.**
 
-## Step 1: Setup
+The autopilot functionality (scan everything, fix what it can, ask questions for the rest) is now available directly from `/comply`. When you run `/comply`, select "Autopilot" mode.
 
-```bash
-_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
-"$_EMDASH_BIN"/comply-db init 2>/dev/null || true
-"$_EMDASH_BIN"/comply-db summary
+**What changed:** em-dash v3 reorganized skills into a guided compliance journey. `/comply` is now the single entry point that handles everything, including autopilot.
 
-# Detect tools
-command -v prowler >/dev/null 2>&1 && echo "TOOL_PROWLER=true" || echo "TOOL_PROWLER=false"
-command -v checkov >/dev/null 2>&1 && echo "TOOL_CHECKOV=true" || echo "TOOL_CHECKOV=false"
-command -v aws >/dev/null 2>&1 && echo "TOOL_AWS=true" || echo "TOOL_AWS=false"
-command -v conftest >/dev/null 2>&1 && echo "TOOL_CONFTEST=true" || echo "TOOL_CONFTEST=false"
-```
+**What to do:** Run `/comply` instead. Select Autopilot when prompted.
 
-```bash
-cat "$_EMDASH_BIN"/../nist/tool-bindings.json
-```
-
-## Step 2: Get next incomplete control
-
-```bash
-"$_EMDASH_BIN"/comply-db query "SELECT oscal_id, title, status FROM controls WHERE status != 'complete' ORDER BY oscal_id LIMIT 1"
-```
-
-If all complete: "All controls addressed! Run `/comply-report` to generate your audit packet."
-
-## Step 3: Load and display the control
-
-```bash
-"$_EMDASH_BIN"/comply-db control <OSCAL_ID>
-```
-
-Tell the user: "Working on [OSCAL_ID]: [title]"
-
-## Step 4: For this control, do EVERYTHING
-
-**4a. Check if tool bindings exist → SCAN**
-
-Look up the control in tool-bindings.json. If it has em-dash/Prowler/Checkov checks:
-- Run each available check
-- Record results: `comply-db update-scan <ID> <PASS|FAIL> <tool> <check_id> "<output>"`
-
-**4b. If any checks FAILED → FIX**
-
-Read the NIST prose to understand what's required. Attempt to fix:
-- Code issues: generate patches
-- Terraform/IaC: modify configuration
-- AWS settings: provide the CLI command to fix it
-
-After fixing, re-run the failed check to verify. Record the new result.
-
-If the fix requires human judgment (e.g., organizational policy decision), flag it:
-"Control [ID] needs manual attention: [what's needed]"
-
-**4c. If control needs interview evidence → ASK**
-
-Read the NIST assessment method. Derive 1-2 questions from it.
-Ask via AskUserQuestion — one question at a time.
-Record the answer as evidence.
-
-**4d. Update control status**
-
-After all actions for this control:
-```bash
-"$_EMDASH_BIN"/comply-db update-scan <ID> <final_result> summary assessment "<what was done>"
-```
-
-## Step 5: Report progress and continue
-
-"Control [ID]: [title] — [result]. [X] of [Y] controls complete."
-
-Go back to Step 2 for the next control.
-
-## Step 6: Session summary (when done or stopped)
-
-When all controls are processed or the user stops:
-```bash
-"$_EMDASH_BIN"/comply-db summary
-```
-
-Show what was accomplished this session:
-- Controls scanned: N
-- Checks run: N (M passed, K failed)
-- Fixes applied: N
-- Questions answered: N
-- Remaining: N controls need attention
-
-## Important
-
-- This is the "fire and forget" mode — do as much as possible with minimal user input
-- Only ask the user when you MUST (interview questions, ambiguous fixes)
-- Record everything to SQLite as you go
-- The user can interrupt at any time — progress is saved
-- For controls with NO tool bindings and NO assessment method, mark as "needs manual review"
+This deprecation wrapper will be removed after 2 minor versions.

--- a/skills/comply-auto/SKILL.md
+++ b/skills/comply-auto/SKILL.md
@@ -1,18 +1,13 @@
 ---
 
 name: comply-auto
-version: 2.0.0
+version: 3.0.0
 description: |
-  HIPAA compliance autopilot. Loops through ALL controls: scans infrastructure,
-  fixes what it can, asks questions for interview-only controls. The "just
-  handle it" command.
+  DEPRECATED — comply-auto is now a mode within /comply.
+  Run /comply and select "Autopilot" mode for the same functionality.
+  This wrapper will be removed in a future version.
 allowed-tools:
   - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
   - AskUserQuestion
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
@@ -23,101 +18,14 @@ allowed-tools:
 > **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
 
 
-# /comply-auto — Compliance Autopilot
+# /comply-auto — Deprecated
 
-You are the autopilot. Loop through every NIST 800-53 control and handle it end-to-end.
+**This skill has been absorbed into `/comply` as "Autopilot" mode.**
 
-## Step 1: Setup
+The autopilot functionality (scan everything, fix what it can, ask questions for the rest) is now available directly from `/comply`. When you run `/comply`, select "Autopilot" mode.
 
-```bash
-_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
-"$_EMDASH_BIN"/comply-db init 2>/dev/null || true
-"$_EMDASH_BIN"/comply-db summary
+**What changed:** em-dash v3 reorganized skills into a guided compliance journey. Instead of separate skills for each action, `/comply` is now the single entry point that handles everything, including the autopilot loop.
 
-# Detect tools
-command -v prowler >/dev/null 2>&1 && echo "TOOL_PROWLER=true" || echo "TOOL_PROWLER=false"
-command -v checkov >/dev/null 2>&1 && echo "TOOL_CHECKOV=true" || echo "TOOL_CHECKOV=false"
-command -v aws >/dev/null 2>&1 && echo "TOOL_AWS=true" || echo "TOOL_AWS=false"
-command -v conftest >/dev/null 2>&1 && echo "TOOL_CONFTEST=true" || echo "TOOL_CONFTEST=false"
-```
+**What to do:** Run `/comply` instead. Select "Autopilot" when prompted for mode.
 
-```bash
-cat "$_EMDASH_BIN"/../nist/tool-bindings.json
-```
-
-## Step 2: Get next incomplete control
-
-```bash
-"$_EMDASH_BIN"/comply-db query "SELECT oscal_id, title, status FROM controls WHERE status != 'complete' ORDER BY oscal_id LIMIT 1"
-```
-
-If all complete: "All controls addressed! Run `/comply-report` to generate your audit packet."
-
-## Step 3: Load and display the control
-
-```bash
-"$_EMDASH_BIN"/comply-db control <OSCAL_ID>
-```
-
-Tell the user: "Working on [OSCAL_ID]: [title]"
-
-## Step 4: For this control, do EVERYTHING
-
-**4a. Check if tool bindings exist → SCAN**
-
-Look up the control in tool-bindings.json. If it has em-dash/Prowler/Checkov checks:
-- Run each available check
-- Record results: `comply-db update-scan <ID> <PASS|FAIL> <tool> <check_id> "<output>"`
-
-**4b. If any checks FAILED → FIX**
-
-Read the NIST prose to understand what's required. Attempt to fix:
-- Code issues: generate patches
-- Terraform/IaC: modify configuration
-- AWS settings: provide the CLI command to fix it
-
-After fixing, re-run the failed check to verify. Record the new result.
-
-If the fix requires human judgment (e.g., organizational policy decision), flag it:
-"Control [ID] needs manual attention: [what's needed]"
-
-**4c. If control needs interview evidence → ASK**
-
-Read the NIST assessment method. Derive 1-2 questions from it.
-Ask via AskUserQuestion — one question at a time.
-Record the answer as evidence.
-
-**4d. Update control status**
-
-After all actions for this control:
-```bash
-"$_EMDASH_BIN"/comply-db update-scan <ID> <final_result> summary assessment "<what was done>"
-```
-
-## Step 5: Report progress and continue
-
-"Control [ID]: [title] — [result]. [X] of [Y] controls complete."
-
-Go back to Step 2 for the next control.
-
-## Step 6: Session summary (when done or stopped)
-
-When all controls are processed or the user stops:
-```bash
-"$_EMDASH_BIN"/comply-db summary
-```
-
-Show what was accomplished this session:
-- Controls scanned: N
-- Checks run: N (M passed, K failed)
-- Fixes applied: N
-- Questions answered: N
-- Remaining: N controls need attention
-
-## Important
-
-- This is the "fire and forget" mode — do as much as possible with minimal user input
-- Only ask the user when you MUST (interview questions, ambiguous fixes)
-- Record everything to SQLite as you go
-- The user can interrupt at any time — progress is saved
-- For controls with NO tool bindings and NO assessment method, mark as "needs manual review"
+This deprecation wrapper will be removed after 2 minor versions.

--- a/skills/comply-auto/SKILL.md
+++ b/skills/comply-auto/SKILL.md
@@ -1,13 +1,18 @@
 ---
 
 name: comply-auto
-version: 3.0.0
+version: 2.0.0
 description: |
-  DEPRECATED — comply-auto is now a mode within /comply.
-  Run /comply and select "Autopilot" mode for the same functionality.
-  This wrapper will be removed in a future version.
+  HIPAA compliance autopilot. Loops through ALL controls: scans infrastructure,
+  fixes what it can, asks questions for interview-only controls. The "just
+  handle it" command.
 allowed-tools:
   - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
   - AskUserQuestion
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
@@ -18,14 +23,101 @@ allowed-tools:
 > **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
 
 
-# /comply-auto — Deprecated
+# /comply-auto — Compliance Autopilot
 
-**This skill has been absorbed into `/comply` as "Autopilot" mode.**
+You are the autopilot. Loop through every NIST 800-53 control and handle it end-to-end.
 
-The autopilot functionality (scan everything, fix what it can, ask questions for the rest) is now available directly from `/comply`. When you run `/comply`, select "Autopilot" mode.
+## Step 1: Setup
 
-**What changed:** em-dash v3 reorganized skills into a guided compliance journey. Instead of separate skills for each action, `/comply` is now the single entry point that handles everything, including the autopilot loop.
+```bash
+_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
+"$_EMDASH_BIN"/comply-db init 2>/dev/null || true
+"$_EMDASH_BIN"/comply-db summary
 
-**What to do:** Run `/comply` instead. Select "Autopilot" when prompted for mode.
+# Detect tools
+command -v prowler >/dev/null 2>&1 && echo "TOOL_PROWLER=true" || echo "TOOL_PROWLER=false"
+command -v checkov >/dev/null 2>&1 && echo "TOOL_CHECKOV=true" || echo "TOOL_CHECKOV=false"
+command -v aws >/dev/null 2>&1 && echo "TOOL_AWS=true" || echo "TOOL_AWS=false"
+command -v conftest >/dev/null 2>&1 && echo "TOOL_CONFTEST=true" || echo "TOOL_CONFTEST=false"
+```
 
-This deprecation wrapper will be removed after 2 minor versions.
+```bash
+cat "$_EMDASH_BIN"/../nist/tool-bindings.json
+```
+
+## Step 2: Get next incomplete control
+
+```bash
+"$_EMDASH_BIN"/comply-db query "SELECT oscal_id, title, status FROM controls WHERE status != 'complete' ORDER BY oscal_id LIMIT 1"
+```
+
+If all complete: "All controls addressed! Run `/comply-report` to generate your audit packet."
+
+## Step 3: Load and display the control
+
+```bash
+"$_EMDASH_BIN"/comply-db control <OSCAL_ID>
+```
+
+Tell the user: "Working on [OSCAL_ID]: [title]"
+
+## Step 4: For this control, do EVERYTHING
+
+**4a. Check if tool bindings exist → SCAN**
+
+Look up the control in tool-bindings.json. If it has em-dash/Prowler/Checkov checks:
+- Run each available check
+- Record results: `comply-db update-scan <ID> <PASS|FAIL> <tool> <check_id> "<output>"`
+
+**4b. If any checks FAILED → FIX**
+
+Read the NIST prose to understand what's required. Attempt to fix:
+- Code issues: generate patches
+- Terraform/IaC: modify configuration
+- AWS settings: provide the CLI command to fix it
+
+After fixing, re-run the failed check to verify. Record the new result.
+
+If the fix requires human judgment (e.g., organizational policy decision), flag it:
+"Control [ID] needs manual attention: [what's needed]"
+
+**4c. If control needs interview evidence → ASK**
+
+Read the NIST assessment method. Derive 1-2 questions from it.
+Ask via AskUserQuestion — one question at a time.
+Record the answer as evidence.
+
+**4d. Update control status**
+
+After all actions for this control:
+```bash
+"$_EMDASH_BIN"/comply-db update-scan <ID> <final_result> summary assessment "<what was done>"
+```
+
+## Step 5: Report progress and continue
+
+"Control [ID]: [title] — [result]. [X] of [Y] controls complete."
+
+Go back to Step 2 for the next control.
+
+## Step 6: Session summary (when done or stopped)
+
+When all controls are processed or the user stops:
+```bash
+"$_EMDASH_BIN"/comply-db summary
+```
+
+Show what was accomplished this session:
+- Controls scanned: N
+- Checks run: N (M passed, K failed)
+- Fixes applied: N
+- Questions answered: N
+- Remaining: N controls need attention
+
+## Important
+
+- This is the "fire and forget" mode — do as much as possible with minimal user input
+- Only ask the user when you MUST (interview questions, ambiguous fixes)
+- Record everything to SQLite as you go
+- The user can interrupt at any time — progress is saved
+- For controls with NO tool bindings and NO assessment method, mark as "needs manual review"

--- a/skills/comply-auto/SKILL.md.tmpl
+++ b/skills/comply-auto/SKILL.md.tmpl
@@ -1,18 +1,13 @@
 ---
 
 name: comply-auto
-version: 2.0.0
+version: 3.0.0
 description: |
-  HIPAA compliance autopilot. Loops through ALL controls: scans infrastructure,
-  fixes what it can, asks questions for interview-only controls. The "just
-  handle it" command.
+  DEPRECATED — comply-auto is now a mode within /comply.
+  Run /comply and select "Autopilot" mode for the same functionality.
+  This wrapper will be removed in a future version.
 allowed-tools:
   - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
   - AskUserQuestion
 ---
 
@@ -21,101 +16,14 @@ allowed-tools:
 > **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
 
 
-# /comply-auto — Compliance Autopilot
+# /comply-auto — Deprecated
 
-You are the autopilot. Loop through every NIST 800-53 control and handle it end-to-end.
+**This skill has been absorbed into `/comply` as "Autopilot" mode.**
 
-## Step 1: Setup
+The autopilot functionality (scan everything, fix what it can, ask questions for the rest) is now available directly from `/comply`. When you run `/comply`, select "Autopilot" mode.
 
-```bash
-_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
-"$_EMDASH_BIN"/comply-db init 2>/dev/null || true
-"$_EMDASH_BIN"/comply-db summary
+**What changed:** em-dash v3 reorganized skills into a guided compliance journey. Instead of separate skills for each action, `/comply` is now the single entry point that handles everything, including the autopilot loop.
 
-# Detect tools
-command -v prowler >/dev/null 2>&1 && echo "TOOL_PROWLER=true" || echo "TOOL_PROWLER=false"
-command -v checkov >/dev/null 2>&1 && echo "TOOL_CHECKOV=true" || echo "TOOL_CHECKOV=false"
-command -v aws >/dev/null 2>&1 && echo "TOOL_AWS=true" || echo "TOOL_AWS=false"
-command -v conftest >/dev/null 2>&1 && echo "TOOL_CONFTEST=true" || echo "TOOL_CONFTEST=false"
-```
+**What to do:** Run `/comply` instead. Select "Autopilot" when prompted for mode.
 
-```bash
-cat "$_EMDASH_BIN"/../nist/tool-bindings.json
-```
-
-## Step 2: Get next incomplete control
-
-```bash
-"$_EMDASH_BIN"/comply-db query "SELECT oscal_id, title, status FROM controls WHERE status != 'complete' ORDER BY oscal_id LIMIT 1"
-```
-
-If all complete: "All controls addressed! Run `/comply-report` to generate your audit packet."
-
-## Step 3: Load and display the control
-
-```bash
-"$_EMDASH_BIN"/comply-db control <OSCAL_ID>
-```
-
-Tell the user: "Working on [OSCAL_ID]: [title]"
-
-## Step 4: For this control, do EVERYTHING
-
-**4a. Check if tool bindings exist → SCAN**
-
-Look up the control in tool-bindings.json. If it has em-dash/Prowler/Checkov checks:
-- Run each available check
-- Record results: `comply-db update-scan <ID> <PASS|FAIL> <tool> <check_id> "<output>"`
-
-**4b. If any checks FAILED → FIX**
-
-Read the NIST prose to understand what's required. Attempt to fix:
-- Code issues: generate patches
-- Terraform/IaC: modify configuration
-- AWS settings: provide the CLI command to fix it
-
-After fixing, re-run the failed check to verify. Record the new result.
-
-If the fix requires human judgment (e.g., organizational policy decision), flag it:
-"Control [ID] needs manual attention: [what's needed]"
-
-**4c. If control needs interview evidence → ASK**
-
-Read the NIST assessment method. Derive 1-2 questions from it.
-Ask via AskUserQuestion — one question at a time.
-Record the answer as evidence.
-
-**4d. Update control status**
-
-After all actions for this control:
-```bash
-"$_EMDASH_BIN"/comply-db update-scan <ID> <final_result> summary assessment "<what was done>"
-```
-
-## Step 5: Report progress and continue
-
-"Control [ID]: [title] — [result]. [X] of [Y] controls complete."
-
-Go back to Step 2 for the next control.
-
-## Step 6: Session summary (when done or stopped)
-
-When all controls are processed or the user stops:
-```bash
-"$_EMDASH_BIN"/comply-db summary
-```
-
-Show what was accomplished this session:
-- Controls scanned: N
-- Checks run: N (M passed, K failed)
-- Fixes applied: N
-- Questions answered: N
-- Remaining: N controls need attention
-
-## Important
-
-- This is the "fire and forget" mode — do as much as possible with minimal user input
-- Only ask the user when you MUST (interview questions, ambiguous fixes)
-- Record everything to SQLite as you go
-- The user can interrupt at any time — progress is saved
-- For controls with NO tool bindings and NO assessment method, mark as "needs manual review"
+This deprecation wrapper will be removed after 2 minor versions.

--- a/skills/comply-auto/SKILL.md.tmpl
+++ b/skills/comply-auto/SKILL.md.tmpl
@@ -1,13 +1,18 @@
 ---
 
 name: comply-auto
-version: 3.0.0
+version: 2.0.0
 description: |
-  DEPRECATED — comply-auto is now a mode within /comply.
-  Run /comply and select "Autopilot" mode for the same functionality.
-  This wrapper will be removed in a future version.
+  HIPAA compliance autopilot. Loops through ALL controls: scans infrastructure,
+  fixes what it can, asks questions for interview-only controls. The "just
+  handle it" command.
 allowed-tools:
   - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
   - AskUserQuestion
 ---
 
@@ -16,14 +21,101 @@ allowed-tools:
 > **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
 
 
-# /comply-auto — Deprecated
+# /comply-auto — Compliance Autopilot
 
-**This skill has been absorbed into `/comply` as "Autopilot" mode.**
+You are the autopilot. Loop through every NIST 800-53 control and handle it end-to-end.
 
-The autopilot functionality (scan everything, fix what it can, ask questions for the rest) is now available directly from `/comply`. When you run `/comply`, select "Autopilot" mode.
+## Step 1: Setup
 
-**What changed:** em-dash v3 reorganized skills into a guided compliance journey. Instead of separate skills for each action, `/comply` is now the single entry point that handles everything, including the autopilot loop.
+```bash
+_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
+"$_EMDASH_BIN"/comply-db init 2>/dev/null || true
+"$_EMDASH_BIN"/comply-db summary
 
-**What to do:** Run `/comply` instead. Select "Autopilot" when prompted for mode.
+# Detect tools
+command -v prowler >/dev/null 2>&1 && echo "TOOL_PROWLER=true" || echo "TOOL_PROWLER=false"
+command -v checkov >/dev/null 2>&1 && echo "TOOL_CHECKOV=true" || echo "TOOL_CHECKOV=false"
+command -v aws >/dev/null 2>&1 && echo "TOOL_AWS=true" || echo "TOOL_AWS=false"
+command -v conftest >/dev/null 2>&1 && echo "TOOL_CONFTEST=true" || echo "TOOL_CONFTEST=false"
+```
 
-This deprecation wrapper will be removed after 2 minor versions.
+```bash
+cat "$_EMDASH_BIN"/../nist/tool-bindings.json
+```
+
+## Step 2: Get next incomplete control
+
+```bash
+"$_EMDASH_BIN"/comply-db query "SELECT oscal_id, title, status FROM controls WHERE status != 'complete' ORDER BY oscal_id LIMIT 1"
+```
+
+If all complete: "All controls addressed! Run `/comply-report` to generate your audit packet."
+
+## Step 3: Load and display the control
+
+```bash
+"$_EMDASH_BIN"/comply-db control <OSCAL_ID>
+```
+
+Tell the user: "Working on [OSCAL_ID]: [title]"
+
+## Step 4: For this control, do EVERYTHING
+
+**4a. Check if tool bindings exist → SCAN**
+
+Look up the control in tool-bindings.json. If it has em-dash/Prowler/Checkov checks:
+- Run each available check
+- Record results: `comply-db update-scan <ID> <PASS|FAIL> <tool> <check_id> "<output>"`
+
+**4b. If any checks FAILED → FIX**
+
+Read the NIST prose to understand what's required. Attempt to fix:
+- Code issues: generate patches
+- Terraform/IaC: modify configuration
+- AWS settings: provide the CLI command to fix it
+
+After fixing, re-run the failed check to verify. Record the new result.
+
+If the fix requires human judgment (e.g., organizational policy decision), flag it:
+"Control [ID] needs manual attention: [what's needed]"
+
+**4c. If control needs interview evidence → ASK**
+
+Read the NIST assessment method. Derive 1-2 questions from it.
+Ask via AskUserQuestion — one question at a time.
+Record the answer as evidence.
+
+**4d. Update control status**
+
+After all actions for this control:
+```bash
+"$_EMDASH_BIN"/comply-db update-scan <ID> <final_result> summary assessment "<what was done>"
+```
+
+## Step 5: Report progress and continue
+
+"Control [ID]: [title] — [result]. [X] of [Y] controls complete."
+
+Go back to Step 2 for the next control.
+
+## Step 6: Session summary (when done or stopped)
+
+When all controls are processed or the user stops:
+```bash
+"$_EMDASH_BIN"/comply-db summary
+```
+
+Show what was accomplished this session:
+- Controls scanned: N
+- Checks run: N (M passed, K failed)
+- Fixes applied: N
+- Questions answered: N
+- Remaining: N controls need attention
+
+## Important
+
+- This is the "fire and forget" mode — do as much as possible with minimal user input
+- Only ask the user when you MUST (interview questions, ambiguous fixes)
+- Record everything to SQLite as you go
+- The user can interrupt at any time — progress is saved
+- For controls with NO tool bindings and NO assessment method, mark as "needs manual review"

--- a/skills/comply-auto/SKILL.md.tmpl
+++ b/skills/comply-auto/SKILL.md.tmpl
@@ -1,18 +1,13 @@
 ---
 
 name: comply-auto
-version: 2.0.0
+version: 3.0.0
 description: |
-  HIPAA compliance autopilot. Loops through ALL controls: scans infrastructure,
-  fixes what it can, asks questions for interview-only controls. The "just
-  handle it" command.
+  DEPRECATED — comply-auto is now a mode within /comply.
+  Run /comply and select Autopilot mode for the same functionality.
+  This wrapper will be removed in a future version.
 allowed-tools:
   - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
   - AskUserQuestion
 ---
 
@@ -21,101 +16,14 @@ allowed-tools:
 > **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
 
 
-# /comply-auto — Compliance Autopilot
+# /comply-auto — Deprecated
 
-You are the autopilot. Loop through every NIST 800-53 control and handle it end-to-end.
+**This skill has been absorbed into `/comply` as Autopilot mode.**
 
-## Step 1: Setup
+The autopilot functionality (scan everything, fix what it can, ask questions for the rest) is now available directly from `/comply`. When you run `/comply`, select "Autopilot" mode.
 
-```bash
-_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
-"$_EMDASH_BIN"/comply-db init 2>/dev/null || true
-"$_EMDASH_BIN"/comply-db summary
+**What changed:** em-dash v3 reorganized skills into a guided compliance journey. `/comply` is now the single entry point that handles everything, including autopilot.
 
-# Detect tools
-command -v prowler >/dev/null 2>&1 && echo "TOOL_PROWLER=true" || echo "TOOL_PROWLER=false"
-command -v checkov >/dev/null 2>&1 && echo "TOOL_CHECKOV=true" || echo "TOOL_CHECKOV=false"
-command -v aws >/dev/null 2>&1 && echo "TOOL_AWS=true" || echo "TOOL_AWS=false"
-command -v conftest >/dev/null 2>&1 && echo "TOOL_CONFTEST=true" || echo "TOOL_CONFTEST=false"
-```
+**What to do:** Run `/comply` instead. Select Autopilot when prompted.
 
-```bash
-cat "$_EMDASH_BIN"/../nist/tool-bindings.json
-```
-
-## Step 2: Get next incomplete control
-
-```bash
-"$_EMDASH_BIN"/comply-db query "SELECT oscal_id, title, status FROM controls WHERE status != 'complete' ORDER BY oscal_id LIMIT 1"
-```
-
-If all complete: "All controls addressed! Run `/comply-report` to generate your audit packet."
-
-## Step 3: Load and display the control
-
-```bash
-"$_EMDASH_BIN"/comply-db control <OSCAL_ID>
-```
-
-Tell the user: "Working on [OSCAL_ID]: [title]"
-
-## Step 4: For this control, do EVERYTHING
-
-**4a. Check if tool bindings exist → SCAN**
-
-Look up the control in tool-bindings.json. If it has em-dash/Prowler/Checkov checks:
-- Run each available check
-- Record results: `comply-db update-scan <ID> <PASS|FAIL> <tool> <check_id> "<output>"`
-
-**4b. If any checks FAILED → FIX**
-
-Read the NIST prose to understand what's required. Attempt to fix:
-- Code issues: generate patches
-- Terraform/IaC: modify configuration
-- AWS settings: provide the CLI command to fix it
-
-After fixing, re-run the failed check to verify. Record the new result.
-
-If the fix requires human judgment (e.g., organizational policy decision), flag it:
-"Control [ID] needs manual attention: [what's needed]"
-
-**4c. If control needs interview evidence → ASK**
-
-Read the NIST assessment method. Derive 1-2 questions from it.
-Ask via AskUserQuestion — one question at a time.
-Record the answer as evidence.
-
-**4d. Update control status**
-
-After all actions for this control:
-```bash
-"$_EMDASH_BIN"/comply-db update-scan <ID> <final_result> summary assessment "<what was done>"
-```
-
-## Step 5: Report progress and continue
-
-"Control [ID]: [title] — [result]. [X] of [Y] controls complete."
-
-Go back to Step 2 for the next control.
-
-## Step 6: Session summary (when done or stopped)
-
-When all controls are processed or the user stops:
-```bash
-"$_EMDASH_BIN"/comply-db summary
-```
-
-Show what was accomplished this session:
-- Controls scanned: N
-- Checks run: N (M passed, K failed)
-- Fixes applied: N
-- Questions answered: N
-- Remaining: N controls need attention
-
-## Important
-
-- This is the "fire and forget" mode — do as much as possible with minimal user input
-- Only ask the user when you MUST (interview questions, ambiguous fixes)
-- Record everything to SQLite as you go
-- The user can interrupt at any time — progress is saved
-- For controls with NO tool bindings and NO assessment method, mark as "needs manual review"
+This deprecation wrapper will be removed after 2 minor versions.

--- a/skills/comply-deal/SKILL.md
+++ b/skills/comply-deal/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: comply-deal
+version: 1.0.0
+description: |
+  Answer prospect security questionnaires using your compliance data.
+  Parses questionnaire text, maps questions to NIST 800-53 controls,
+  checks current compliance posture, and generates an answer pack.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+## DISCLAIMER
+
+> **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
+
+
+# /comply-deal — Security Questionnaire Response
+
+Answer prospect security questionnaires using your existing compliance evidence.
+
+## Step 1: Check compliance data exists
+
+```bash
+_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
+_SLUG=$("$_EMDASH_BIN"/comply-slug 2>/dev/null | grep SLUG= | cut -d= -f2)
+_DB_PATH=~/.em-dash/projects/$_SLUG/compliance.db
+[ -f "$_DB_PATH" ] && echo "DB_EXISTS" || echo "NO_DB"
+```
+
+If NO_DB: "No compliance data found. Run `/hipaa` or another framework command first to build your compliance posture, then come back to answer questionnaires."
+
+## Step 2: Load current compliance posture
+
+```bash
+"$_EMDASH_BIN"/comply-db summary 2>/dev/null
+"$_EMDASH_BIN"/comply-db status 2>/dev/null
+```
+
+## Step 3: Get the questionnaire
+
+Ask via AskUserQuestion:
+
+> "Paste the security questionnaire text below, or provide the path to a file (CSV or plain text). I'll map each question to your compliance controls and generate answers."
+>
+> - A) I'll paste the questionnaire text in my next message
+> - B) I have a file — let me provide the path
+
+If A: Ask them to paste the questionnaire.
+If B: Ask for the file path, then read it with the Read tool.
+
+## Step 4: Parse and map questions
+
+For each question in the questionnaire:
+
+1. **Understand the question** — what compliance area does it address? (encryption, access control, logging, incident response, backup, training, etc.)
+2. **Map to NIST 800-53 controls** — identify which control(s) the question relates to (e.g., "Do you encrypt data at rest?" → SC-28)
+3. **Check posture** — look up the control's status in the SQLite database
+
+Classify each question:
+
+- **GREEN**: The mapped control(s) have status PASS with evidence. Generate a confident answer citing the evidence.
+- **YELLOW**: The mapped control(s) are in progress or have partial evidence. Generate a qualified answer noting what's done and what's pending.
+- **RED**: The mapped control(s) FAIL or have no evidence. Flag as a gap and suggest remediation.
+
+## Step 5: Generate the answer pack
+
+Output a structured response:
+
+1. **Summary**: "X of Y questions answered confidently, Z need work."
+2. **GREEN answers**: For each, provide the draft answer with evidence citations.
+3. **YELLOW answers**: For each, provide what can be said today and what's missing.
+4. **RED gaps**: For each, explain what control is needed and suggest `/comply-fix`.
+
+## Step 6: Next steps
+
+- "Want to fix the gaps? Run `/comply-fix` to remediate failing controls."
+- "Want a shareable trust page? Run `/comply-report` with the trust page option."
+
+Update journey:
+```bash
+"$_EMDASH_BIN"/comply-db journey complete --milestone 6 2>/dev/null || true
+```

--- a/skills/comply-deal/SKILL.md.tmpl
+++ b/skills/comply-deal/SKILL.md.tmpl
@@ -1,0 +1,85 @@
+---
+name: comply-deal
+version: 1.0.0
+description: |
+  Answer prospect security questionnaires using your compliance data.
+  Parses questionnaire text, maps questions to NIST 800-53 controls,
+  checks current compliance posture, and generates an answer pack.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+---
+
+## DISCLAIMER
+
+> **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
+
+
+# /comply-deal — Security Questionnaire Response
+
+Answer prospect security questionnaires using your existing compliance evidence.
+
+## Step 1: Check compliance data exists
+
+```bash
+_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
+_SLUG=$("$_EMDASH_BIN"/comply-slug 2>/dev/null | grep SLUG= | cut -d= -f2)
+_DB_PATH=~/.em-dash/projects/$_SLUG/compliance.db
+[ -f "$_DB_PATH" ] && echo "DB_EXISTS" || echo "NO_DB"
+```
+
+If NO_DB: "No compliance data found. Run `/hipaa` or another framework command first to build your compliance posture, then come back to answer questionnaires."
+
+## Step 2: Load current compliance posture
+
+```bash
+"$_EMDASH_BIN"/comply-db summary 2>/dev/null
+"$_EMDASH_BIN"/comply-db status 2>/dev/null
+```
+
+## Step 3: Get the questionnaire
+
+Ask via AskUserQuestion:
+
+> "Paste the security questionnaire text below, or provide the path to a file (CSV or plain text). I'll map each question to your compliance controls and generate answers."
+>
+> - A) I'll paste the questionnaire text in my next message
+> - B) I have a file — let me provide the path
+
+If A: Ask them to paste the questionnaire.
+If B: Ask for the file path, then read it with the Read tool.
+
+## Step 4: Parse and map questions
+
+For each question in the questionnaire:
+
+1. **Understand the question** — what compliance area does it address? (encryption, access control, logging, incident response, backup, training, etc.)
+2. **Map to NIST 800-53 controls** — identify which control(s) the question relates to (e.g., "Do you encrypt data at rest?" → SC-28)
+3. **Check posture** — look up the control's status in the SQLite database
+
+Classify each question:
+
+- **GREEN**: The mapped control(s) have status PASS with evidence. Generate a confident answer citing the evidence.
+- **YELLOW**: The mapped control(s) are in progress or have partial evidence. Generate a qualified answer noting what's done and what's pending.
+- **RED**: The mapped control(s) FAIL or have no evidence. Flag as a gap and suggest remediation.
+
+## Step 5: Generate the answer pack
+
+Output a structured response:
+
+1. **Summary**: "X of Y questions answered confidently, Z need work."
+2. **GREEN answers**: For each, provide the draft answer with evidence citations.
+3. **YELLOW answers**: For each, provide what can be said today and what's missing.
+4. **RED gaps**: For each, explain what control is needed and suggest `/comply-fix`.
+
+## Step 6: Next steps
+
+- "Want to fix the gaps? Run `/comply-fix` to remediate failing controls."
+- "Want a shareable trust page? Run `/comply-report` with the trust page option."
+
+Update journey:
+```bash
+"$_EMDASH_BIN"/comply-db journey complete --milestone 6 2>/dev/null || true
+```

--- a/skills/comply-explain/SKILL.md
+++ b/skills/comply-explain/SKILL.md
@@ -1,0 +1,104 @@
+---
+
+name: comply-explain
+version: 1.0.0
+description: |
+  Explain any compliance standard in plain English, in context.
+  Accepts NIST control IDs (SC-28), HIPAA CFR sections (164.312(a)(2)(iv)),
+  or natural language queries (encryption). Searches authoritative .gov
+  sources when available. Can be triggered by user or by Claude when relevant.
+allowed-tools:
+  - Bash
+  - Read
+  - WebSearch
+  - AskUserQuestion
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+## DISCLAIMER
+
+> **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
+
+
+# /comply-explain — Understand Any Compliance Standard
+
+Explain a compliance control in plain English, tailored to the user's specific context and stack.
+
+## Step 1: Parse Input
+
+The user may provide:
+- A **NIST control ID** like `SC-28` or `AC-2`
+- A **HIPAA CFR section** like `164.312(a)(2)(iv)`
+- A **natural language query** like `encryption` or `access control`
+
+If the input looks like a NIST ID or CFR section (starts with letters+dash+numbers, or starts with `164.`), use it directly.
+
+If the input looks like natural language, read `nist/plain-english.json` and search for controls where `plain_english`, `why_it_matters`, or `nist_name` match the query. If multiple controls match, present a disambiguation list:
+
+> "Several controls relate to [query]. Which one?"
+> 1. SC-28 — Encryption at rest (Patient data must be encrypted when stored)
+> 2. SC-13 — Cryptographic protection (Use real encryption, not homebrew)
+> 3. SC-8 — Transmission security (Encrypt data in transit)
+
+Ask the user to pick one using AskUserQuestion. Then proceed with that control ID.
+
+## Step 2: Get Control Data
+
+```bash
+_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
+"$_EMDASH_BIN"/comply-db control <ID> --json
+```
+
+Replace `<ID>` with the NIST control ID or HIPAA CFR section from Step 1.
+
+If the command fails (no database initialized), try the `--json` flag anyway — the command reads from data files (plain-english.json, NIST catalog) even without a SQLite database.
+
+## Step 3: Format the Explanation
+
+Using the JSON output, build a conversational explanation for the user. Follow this structure:
+
+1. **Lead with the plain-English explanation.** Use the `plain_english` field. This is the first thing the user reads.
+
+2. **Explain why it matters.** Use the `why_it_matters` field. Connect it to real consequences.
+
+3. **Stack-specific guidance.** If `detected_stack` is populated (e.g., `["aws"]`), tailor the explanation:
+   - AWS + SC-28 → "In your case, this means enabling RDS encryption and S3 default encryption."
+   - Auth0 + AC-2 → "Auth0 handles unique logins for you, but you still need to manage access levels."
+   - Generate this contextual guidance based on the control and detected vendors.
+
+4. **Related controls.** If `related_controls` is non-empty, mention the most relevant 2-3:
+   - "This connects to SC-13 (Cryptographic Protection) — SC-13 defines WHICH crypto to use, SC-28 says USE it at rest."
+
+5. **Current status.** If `status` is not "unknown", tell the user where they stand:
+   - "pending" → "You haven't addressed this yet."
+   - "partial" → "You've started on this but it's not complete."
+   - "complete" → "This control is verified and passing."
+
+6. **Verification approach.** If `verification` is present:
+   - automated → "This can be verified automatically using [tools]."
+   - interview_only → "This requires an interview/document review — no automated check exists."
+
+7. **If `--simple` was requested or the user asks for a simpler explanation:** Generate an analogy-based ELI5 version. Example: "Think of encryption like a safe. Right now your patient data is sitting on a desk where anyone can read it. Encryption puts it in a safe — even if someone breaks into your office, they can't read the contents."
+
+## Step 4: Add Authoritative Sources
+
+If WebSearch is available, search for official guidance:
+
+```
+Query: "HIPAA [CFR section] [control name] guidance"
+Allowed domains: hhs.gov, nist.gov, healthit.gov
+```
+
+Append 1-2 source links at the end of the explanation. Only cite .gov sources.
+
+If WebSearch is not available, append:
+> For official guidance, see: https://www.hhs.gov/hipaa/for-professionals
+
+## Tone
+
+- Plain English. No jargon unless explaining the jargon itself.
+- Concrete examples over abstract descriptions.
+- Connect to the user's actual situation when stack context is available.
+- Be honest about what the control requires without sugar-coating.
+- Encourage, don't lecture. The user is trying to do the right thing.

--- a/skills/comply-explain/SKILL.md.tmpl
+++ b/skills/comply-explain/SKILL.md.tmpl
@@ -1,0 +1,102 @@
+---
+
+name: comply-explain
+version: 1.0.0
+description: |
+  Explain any compliance standard in plain English, in context.
+  Accepts NIST control IDs (SC-28), HIPAA CFR sections (164.312(a)(2)(iv)),
+  or natural language queries (encryption). Searches authoritative .gov
+  sources when available. Can be triggered by user or by Claude when relevant.
+allowed-tools:
+  - Bash
+  - Read
+  - WebSearch
+  - AskUserQuestion
+---
+
+## DISCLAIMER
+
+> **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
+
+
+# /comply-explain — Understand Any Compliance Standard
+
+Explain a compliance control in plain English, tailored to the user's specific context and stack.
+
+## Step 1: Parse Input
+
+The user may provide:
+- A **NIST control ID** like `SC-28` or `AC-2`
+- A **HIPAA CFR section** like `164.312(a)(2)(iv)`
+- A **natural language query** like `encryption` or `access control`
+
+If the input looks like a NIST ID or CFR section (starts with letters+dash+numbers, or starts with `164.`), use it directly.
+
+If the input looks like natural language, read `nist/plain-english.json` and search for controls where `plain_english`, `why_it_matters`, or `nist_name` match the query. If multiple controls match, present a disambiguation list:
+
+> "Several controls relate to [query]. Which one?"
+> 1. SC-28 — Encryption at rest (Patient data must be encrypted when stored)
+> 2. SC-13 — Cryptographic protection (Use real encryption, not homebrew)
+> 3. SC-8 — Transmission security (Encrypt data in transit)
+
+Ask the user to pick one using AskUserQuestion. Then proceed with that control ID.
+
+## Step 2: Get Control Data
+
+```bash
+_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
+"$_EMDASH_BIN"/comply-db control <ID> --json
+```
+
+Replace `<ID>` with the NIST control ID or HIPAA CFR section from Step 1.
+
+If the command fails (no database initialized), try the `--json` flag anyway — the command reads from data files (plain-english.json, NIST catalog) even without a SQLite database.
+
+## Step 3: Format the Explanation
+
+Using the JSON output, build a conversational explanation for the user. Follow this structure:
+
+1. **Lead with the plain-English explanation.** Use the `plain_english` field. This is the first thing the user reads.
+
+2. **Explain why it matters.** Use the `why_it_matters` field. Connect it to real consequences.
+
+3. **Stack-specific guidance.** If `detected_stack` is populated (e.g., `["aws"]`), tailor the explanation:
+   - AWS + SC-28 → "In your case, this means enabling RDS encryption and S3 default encryption."
+   - Auth0 + AC-2 → "Auth0 handles unique logins for you, but you still need to manage access levels."
+   - Generate this contextual guidance based on the control and detected vendors.
+
+4. **Related controls.** If `related_controls` is non-empty, mention the most relevant 2-3:
+   - "This connects to SC-13 (Cryptographic Protection) — SC-13 defines WHICH crypto to use, SC-28 says USE it at rest."
+
+5. **Current status.** If `status` is not "unknown", tell the user where they stand:
+   - "pending" → "You haven't addressed this yet."
+   - "partial" → "You've started on this but it's not complete."
+   - "complete" → "This control is verified and passing."
+
+6. **Verification approach.** If `verification` is present:
+   - automated → "This can be verified automatically using [tools]."
+   - interview_only → "This requires an interview/document review — no automated check exists."
+
+7. **If `--simple` was requested or the user asks for a simpler explanation:** Generate an analogy-based ELI5 version. Example: "Think of encryption like a safe. Right now your patient data is sitting on a desk where anyone can read it. Encryption puts it in a safe — even if someone breaks into your office, they can't read the contents."
+
+## Step 4: Add Authoritative Sources
+
+If WebSearch is available, search for official guidance:
+
+```
+Query: "HIPAA [CFR section] [control name] guidance"
+Allowed domains: hhs.gov, nist.gov, healthit.gov
+```
+
+Append 1-2 source links at the end of the explanation. Only cite .gov sources.
+
+If WebSearch is not available, append:
+> For official guidance, see: https://www.hhs.gov/hipaa/for-professionals
+
+## Tone
+
+- Plain English. No jargon unless explaining the jargon itself.
+- Concrete examples over abstract descriptions.
+- Connect to the user's actual situation when stack context is available.
+- Be honest about what the control requires without sugar-coating.
+- Encourage, don't lecture. The user is trying to do the right thing.

--- a/skills/comply-policy/SKILL.md
+++ b/skills/comply-policy/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: comply-policy
+version: 1.0.0
+description: |
+  Generate personalized compliance policy documents from assessment data.
+  Reads your tech stack, data flows, and control status from SQLite,
+  then generates policies that reference your actual infrastructure.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Glob
+  - AskUserQuestion
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+## DISCLAIMER
+
+> **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
+
+
+# /comply-policy — Policy Document Generator
+
+Generate personalized compliance policy documents using your assessment data and tech stack.
+
+## Step 1: Check compliance data exists
+
+```bash
+_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
+_SLUG=$("$_EMDASH_BIN"/comply-slug 2>/dev/null | grep SLUG= | cut -d= -f2)
+_DB_PATH=~/.em-dash/projects/$_SLUG/compliance.db
+[ -f "$_DB_PATH" ] && echo "DB_EXISTS" || echo "NO_DB"
+```
+
+If NO_DB: "No compliance data found. Run `/hipaa` or another framework command first to complete an assessment, then come back to generate policies."
+
+## Step 2: Load assessment context
+
+```bash
+"$_EMDASH_BIN"/comply-db query "SELECT * FROM vendor_registry" 2>/dev/null || echo "NO_VENDORS"
+"$_EMDASH_BIN"/comply-db query "SELECT * FROM phi_data_flows" 2>/dev/null || echo "NO_FLOWS"
+"$_EMDASH_BIN"/comply-db query "SELECT key, value FROM metadata WHERE key IN ('framework', 'active_frameworks')" 2>/dev/null
+"$_EMDASH_BIN"/comply-db summary 2>/dev/null
+```
+
+If vendor_registry AND phi_data_flows are both empty: "No assessment data found. Run your framework command (e.g., `/hipaa`) to complete the assessment interview first. The policy generator needs to know your tech stack, data flows, and vendors to generate personalized policies."
+
+## Step 3: Read existing policy templates
+
+```bash
+ls templates/policies/ 2>/dev/null
+```
+
+These templates provide structural scaffolding. The generator personalizes each section with your actual assessment data.
+
+## Step 4: Ask which policies to generate
+
+Use AskUserQuestion:
+
+> "Which policies do you want to generate? I'll personalize each one with your actual tech stack, data flows, and vendors."
+>
+> - A) Incident Response Plan — what to do when a breach happens
+> - B) Privacy Policy — how you handle personal/patient data
+> - C) Security Policy — your technical security controls
+> - D) Data Retention Policy — how long you keep data and how you dispose of it
+> - E) BAA Template — template for business associate agreements with vendors
+> - F) All of the above
+
+## Step 5: Generate each selected policy
+
+For each policy, generate a complete document following this structure:
+
+```markdown
+# [Policy Name]
+## [Project Name] — Compliance Policy
+
+**Version:** 1.0
+**Effective Date:** [today's date]
+**Last Reviewed:** [today's date]
+**Owner:** [from assessment if available, otherwise "To be assigned"]
+
+## Purpose
+[Plain-English: why this policy exists, what it protects]
+
+## Scope
+[From assessment: which systems, data types, and people this covers.
+ Reference actual vendors from vendor_registry.
+ Reference actual data flows from phi_data_flows.]
+
+## Policy Statements
+[Generated from framework requirements.
+ Each statement cites the specific NIST control.
+ Use plain-English descriptions.]
+
+## Procedures
+[Specific to the user's stack.
+ Reference actual cloud provider, auth system, database.
+ Don't say "your cloud provider" — say "AWS us-east-1" or whatever they use.]
+
+## Responsibilities
+[From assessment: who does what.]
+
+## Review Schedule
+[Annual for most, quarterly for incident response.]
+```
+
+Write each policy to `policies/<policy-name>.md` in the project directory.
+
+## Step 6: Evidence and signing
+
+For each generated policy, tell the user:
+
+"Policy generated at `policies/<policy-name>.md`. Read it carefully — you should understand every policy before signing. When ready, you can sign it with `comply-attest`."
+
+## Step 7: Update journey
+
+```bash
+"$_EMDASH_BIN"/comply-db journey complete --milestone 3 2>/dev/null || true
+```
+
+"Policies generated. Your next step is setting up PR-level compliance checking (Milestone 4). Run `/comply` to continue."

--- a/skills/comply-policy/SKILL.md.tmpl
+++ b/skills/comply-policy/SKILL.md.tmpl
@@ -1,0 +1,120 @@
+---
+name: comply-policy
+version: 1.0.0
+description: |
+  Generate personalized compliance policy documents from assessment data.
+  Reads your tech stack, data flows, and control status from SQLite,
+  then generates policies that reference your actual infrastructure.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Glob
+  - AskUserQuestion
+---
+
+## DISCLAIMER
+
+> **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
+
+
+# /comply-policy — Policy Document Generator
+
+Generate personalized compliance policy documents using your assessment data and tech stack.
+
+## Step 1: Check compliance data exists
+
+```bash
+_EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
+_SLUG=$("$_EMDASH_BIN"/comply-slug 2>/dev/null | grep SLUG= | cut -d= -f2)
+_DB_PATH=~/.em-dash/projects/$_SLUG/compliance.db
+[ -f "$_DB_PATH" ] && echo "DB_EXISTS" || echo "NO_DB"
+```
+
+If NO_DB: "No compliance data found. Run `/hipaa` or another framework command first to complete an assessment, then come back to generate policies."
+
+## Step 2: Load assessment context
+
+```bash
+"$_EMDASH_BIN"/comply-db query "SELECT * FROM vendor_registry" 2>/dev/null || echo "NO_VENDORS"
+"$_EMDASH_BIN"/comply-db query "SELECT * FROM phi_data_flows" 2>/dev/null || echo "NO_FLOWS"
+"$_EMDASH_BIN"/comply-db query "SELECT key, value FROM metadata WHERE key IN ('framework', 'active_frameworks')" 2>/dev/null
+"$_EMDASH_BIN"/comply-db summary 2>/dev/null
+```
+
+If vendor_registry AND phi_data_flows are both empty: "No assessment data found. Run your framework command (e.g., `/hipaa`) to complete the assessment interview first. The policy generator needs to know your tech stack, data flows, and vendors to generate personalized policies."
+
+## Step 3: Read existing policy templates
+
+```bash
+ls templates/policies/ 2>/dev/null
+```
+
+These templates provide structural scaffolding. The generator personalizes each section with your actual assessment data.
+
+## Step 4: Ask which policies to generate
+
+Use AskUserQuestion:
+
+> "Which policies do you want to generate? I'll personalize each one with your actual tech stack, data flows, and vendors."
+>
+> - A) Incident Response Plan — what to do when a breach happens
+> - B) Privacy Policy — how you handle personal/patient data
+> - C) Security Policy — your technical security controls
+> - D) Data Retention Policy — how long you keep data and how you dispose of it
+> - E) BAA Template — template for business associate agreements with vendors
+> - F) All of the above
+
+## Step 5: Generate each selected policy
+
+For each policy, generate a complete document following this structure:
+
+```markdown
+# [Policy Name]
+## [Project Name] — Compliance Policy
+
+**Version:** 1.0
+**Effective Date:** [today's date]
+**Last Reviewed:** [today's date]
+**Owner:** [from assessment if available, otherwise "To be assigned"]
+
+## Purpose
+[Plain-English: why this policy exists, what it protects]
+
+## Scope
+[From assessment: which systems, data types, and people this covers.
+ Reference actual vendors from vendor_registry.
+ Reference actual data flows from phi_data_flows.]
+
+## Policy Statements
+[Generated from framework requirements.
+ Each statement cites the specific NIST control.
+ Use plain-English descriptions.]
+
+## Procedures
+[Specific to the user's stack.
+ Reference actual cloud provider, auth system, database.
+ Don't say "your cloud provider" — say "AWS us-east-1" or whatever they use.]
+
+## Responsibilities
+[From assessment: who does what.]
+
+## Review Schedule
+[Annual for most, quarterly for incident response.]
+```
+
+Write each policy to `policies/<policy-name>.md` in the project directory.
+
+## Step 6: Evidence and signing
+
+For each generated policy, tell the user:
+
+"Policy generated at `policies/<policy-name>.md`. Read it carefully — you should understand every policy before signing. When ready, you can sign it with `comply-attest`."
+
+## Step 7: Update journey
+
+```bash
+"$_EMDASH_BIN"/comply-db journey complete --milestone 3 2>/dev/null || true
+```
+
+"Policies generated. Your next step is setting up PR-level compliance checking (Milestone 4). Run `/comply` to continue."

--- a/skills/comply-report/SKILL.md
+++ b/skills/comply-report/SKILL.md
@@ -31,7 +31,7 @@ _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-da
 ```
 
 Show the user their compliance score. If less than 50% complete, warn:
-"Your compliance coverage is low. Consider running `/comply-auto` first."
+"Your compliance coverage is low. Consider running `/comply` first to build your compliance posture."
 
 ## Step 2: Generate report
 

--- a/skills/comply-report/SKILL.md.tmpl
+++ b/skills/comply-report/SKILL.md.tmpl
@@ -29,7 +29,7 @@ _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-da
 ```
 
 Show the user their compliance score. If less than 50% complete, warn:
-"Your compliance coverage is low. Consider running `/comply-auto` first."
+"Your compliance coverage is low. Consider running `/comply` first to build your compliance posture."
 
 ## Step 2: Generate report
 

--- a/skills/comply/SKILL.md
+++ b/skills/comply/SKILL.md
@@ -1,13 +1,17 @@
 ---
 
 name: comply
-version: 2.0.0
+version: 3.0.0
 description: |
-  Compliance status dashboard. Shows progress across all active frameworks.
-  To start a specific framework, use /hipaa, /soc2, /gdpr, or /pci-dss.
+  Compliance journey engine. The single entry point for all compliance work.
+  Guides founders through 6 milestones, offers autopilot for engineers,
+  shows persona-aware status for compliance officers.
 allowed-tools:
   - Bash
   - Read
+  - Glob
+  - Grep
+  - Write
   - AskUserQuestion
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
@@ -18,11 +22,9 @@ allowed-tools:
 > **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
 
 
-# /comply — Compliance Status
+# /comply — Compliance Journey Engine
 
-Show compliance status across all active frameworks.
-
-## Step 1: Check if any framework is initialized
+## Step 1: Setup and state detection
 
 ```bash
 _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
@@ -31,37 +33,136 @@ _DB_PATH=~/.em-dash/projects/$_SLUG/compliance.db
 [ -f "$_DB_PATH" ] && echo "DB_EXISTS" || echo "NO_DB"
 ```
 
-## Step 2: If NO_DB — no framework initialized yet
+## Step 2: Persona detection
 
-Tell the user:
+```bash
+"$_EMDASH_BIN"/comply-db config get persona 2>/dev/null || echo ""
+```
 
-"No compliance framework initialized yet. Start with one of these:
+If persona is empty (not set), ask via AskUserQuestion:
 
-- `/hipaa` — healthcare, patient data (PHI)
-- `/soc2` — SaaS trust service criteria
-- `/gdpr` — EU data protection
-- `/pci-dss` — payment card security
+> "Welcome to em-dash. How would you describe your role? This helps me adapt my recommendations."
+>
+> - A) **Founder** — I'm building a product and need to understand compliance
+> - B) **Engineer** — I'm implementing compliance controls in code
+> - C) **Compliance Officer** — I manage audits, policies, and formal assessments
 
-You can add multiple frameworks — controls are shared automatically."
+Store the answer:
+- A: `"$_EMDASH_BIN"/comply-db config set persona founder && "$_EMDASH_BIN"/comply-db config set explain always`
+- B: `"$_EMDASH_BIN"/comply-db config set persona engineer && "$_EMDASH_BIN"/comply-db config set explain on-demand`
+- C: `"$_EMDASH_BIN"/comply-db config set persona audit && "$_EMDASH_BIN"/comply-db config set explain off`
 
-## Step 3: If DB_EXISTS — show status
+## Step 3: If NO_DB — Framework Advisor (Milestone 1)
 
+This is the first-time user experience. Run the Framework Advisor inline.
+
+Ask these 3 questions via AskUserQuestion, one at a time:
+
+### Q1: What data do you handle?
+
+> "What kind of data does your product handle?"
+>
+> - A) Patient or health data (names, diagnoses, prescriptions, medical records) → HIPAA
+> - B) Payment card data (credit card numbers, CVVs) → PCI-DSS
+> - C) Personal data of EU residents (names, emails, addresses of EU users) → GDPR
+> - D) General customer data (names, emails, usage data) → SOC 2
+
+### Q2: Who are your customers?
+
+> "Who are you selling to?"
+>
+> - A) Healthcare organizations → also add SOC 2 (enterprise health deals need both)
+> - B) Enterprise / B2B → also add SOC 2 if not already selected
+> - C) Consumers → no change
+> - D) Government → note NIST 800-53 direct mapping
+
+### Q3: Timeline pressure?
+
+> "What's driving your compliance timeline?"
+>
+> - A) A prospect or customer asked for it → prioritize that framework
+> - B) Proactive → start with the data-type framework
+> - C) An investor asked → SOC 2 first
+> - D) No specific pressure → start with the data-type framework
+
+### Output recommendation
+
+Based on answers, tell the user which frameworks they need NOW, LATER, and can SKIP.
+
+If multiple frameworks: "Good news: many controls overlap between frameworks. Do [primary] first and you'll have a head start on [secondary]."
+
+Initialize the recommended frameworks:
+```bash
+"$_EMDASH_BIN"/comply-db init --framework <primary>
+"$_EMDASH_BIN"/comply-db journey init --framework <primary>
+"$_EMDASH_BIN"/comply-db journey complete --milestone 1 --framework <primary>
+```
+
+Tell the user: **"Your next step is `/hipaa` (or whichever framework was recommended). It will walk you through an assessment of your stack."**
+
+## Step 4: If DB_EXISTS — Journey state routing
+
+```bash
+"$_EMDASH_BIN"/comply-db journey status 2>/dev/null || echo '{"initialized":false}'
+```
+
+### If journey not initialized (legacy user):
+
+Initialize and mark M1 complete (they already picked their framework):
+```bash
+"$_EMDASH_BIN"/comply-db journey init
+"$_EMDASH_BIN"/comply-db journey complete --milestone 1
+```
+
+### If journey in progress — route to current milestone:
+
+Read `current_milestone` from the JSON. Route based on milestone:
+
+- **M2 (Assessment & Scan):** "Run `/hipaa` (or your framework) to start the assessment interview and scan."
+- **M3 (Policy Generator):** "Run `/comply-policy` to generate personalized compliance policy documents."
+- **M4 (PR Gate Setup):** "Protect your compliance as you build. Run `bin/comply-check --diff HEAD~1` locally to check your code. To set up automated checking, add the em-dash GitHub Action."
+- **M5 (Trust Page):** "Generate a shareable compliance page for prospects. Run `/comply-report` with the trust page option."
+- **M6 (Deal Rescue):** "Got a security questionnaire from a prospect? Run `/comply-deal` to answer it."
+
+### If journey complete:
+
+Show summary and congratulate:
+```bash
+"$_EMDASH_BIN"/comply-db summary
+```
+
+"All milestones complete. Your compliance journey is done. Run `/comply-report` to generate your audit packet, or `/em-dashboard` for the visual view."
+
+## Step 5: Persona-aware status and recommendations
+
+Show current status:
 ```bash
 "$_EMDASH_BIN"/comply-db summary
 "$_EMDASH_BIN"/comply-db status
 ```
 
-Show which frameworks are active:
-```bash
-"$_EMDASH_BIN"/comply-db query "SELECT key, value FROM metadata WHERE key = 'framework'"
-```
+Read the persona and tailor recommendations:
 
-## Step 4: Recommend next step
+**Founder persona:**
+- Plain English descriptions. "You need to encrypt stored patient data" not "SC-28: Protection of Information at Rest"
+- Focus on journey milestones. "Your next milestone is generating policies."
+- Offer autopilot: "Want me to handle everything? I can scan your code, fix issues, and ask you questions one at a time."
 
-- **0% complete:** "Run `/comply-auto` to start."
-- **Some scans done:** "Run `/comply-assess` for interviews or `/comply-scan` for checks."
-- **Failures found:** "Run `/comply-fix` to remediate."
-- **Complete:** "Run `/comply-report` to generate your audit packet."
+**Engineer persona:**
+- Technical details. Control IDs, check results, specific file paths.
+- Action-oriented: "3 controls failing. Run `/comply-fix` to remediate." or "Run `/comply-scan` for a fresh check."
+- PR gate: "Run `bin/comply-check --diff HEAD~1` before pushing."
 
-Want to add another framework? Run `/soc2`, `/gdpr`, or `/pci-dss`.
-Want the visual dashboard? Run `/em-dashboard`.
+**Audit persona:**
+- Formal workflow focus. "Run `/comply-assess` for structured compliance interviews."
+- Reports: "Run `/comply-report` to generate your signed audit packet."
+- Simulation: "Run `/hipaa-audit` for a 7-phase mock HHS OCR audit."
+- Questionnaires: "Run `/comply-deal` to answer prospect security questionnaires."
+- Policies: "Run `/comply-policy` to generate or update compliance policy documents."
+
+## Always mention
+
+- Add frameworks: `/hipaa`, `/soc2`, `/gdpr`, `/pci-dss`
+- Visual dashboard: `/em-dashboard`
+- Breach response: `/comply-breach`
+- Check your code: `bin/comply-check --diff HEAD~1`

--- a/skills/comply/SKILL.md.tmpl
+++ b/skills/comply/SKILL.md.tmpl
@@ -1,13 +1,17 @@
 ---
 
 name: comply
-version: 2.0.0
+version: 3.0.0
 description: |
-  Compliance status dashboard. Shows progress across all active frameworks.
-  To start a specific framework, use /hipaa, /soc2, /gdpr, or /pci-dss.
+  Compliance journey engine. The single entry point for all compliance work.
+  Guides founders through 6 milestones, offers autopilot for engineers,
+  shows persona-aware status for compliance officers.
 allowed-tools:
   - Bash
   - Read
+  - Glob
+  - Grep
+  - Write
   - AskUserQuestion
 ---
 
@@ -16,11 +20,9 @@ allowed-tools:
 > **IMPORTANT:** This tool provides technical guidance for implementing compliance controls. It is NOT legal advice and does not constitute certification. Consult qualified legal counsel for formal compliance verification.
 
 
-# /comply — Compliance Status
+# /comply — Compliance Journey Engine
 
-Show compliance status across all active frameworks.
-
-## Step 1: Check if any framework is initialized
+## Step 1: Setup and state detection
 
 ```bash
 _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
@@ -29,37 +31,136 @@ _DB_PATH=~/.em-dash/projects/$_SLUG/compliance.db
 [ -f "$_DB_PATH" ] && echo "DB_EXISTS" || echo "NO_DB"
 ```
 
-## Step 2: If NO_DB — no framework initialized yet
+## Step 2: Persona detection
 
-Tell the user:
+```bash
+"$_EMDASH_BIN"/comply-db config get persona 2>/dev/null || echo ""
+```
 
-"No compliance framework initialized yet. Start with one of these:
+If persona is empty (not set), ask via AskUserQuestion:
 
-- `/hipaa` — healthcare, patient data (PHI)
-- `/soc2` — SaaS trust service criteria
-- `/gdpr` — EU data protection
-- `/pci-dss` — payment card security
+> "Welcome to em-dash. How would you describe your role? This helps me adapt my recommendations."
+>
+> - A) **Founder** — I'm building a product and need to understand compliance
+> - B) **Engineer** — I'm implementing compliance controls in code
+> - C) **Compliance Officer** — I manage audits, policies, and formal assessments
 
-You can add multiple frameworks — controls are shared automatically."
+Store the answer:
+- A: `"$_EMDASH_BIN"/comply-db config set persona founder && "$_EMDASH_BIN"/comply-db config set explain always`
+- B: `"$_EMDASH_BIN"/comply-db config set persona engineer && "$_EMDASH_BIN"/comply-db config set explain on-demand`
+- C: `"$_EMDASH_BIN"/comply-db config set persona audit && "$_EMDASH_BIN"/comply-db config set explain off`
 
-## Step 3: If DB_EXISTS — show status
+## Step 3: If NO_DB — Framework Advisor (Milestone 1)
 
+This is the first-time user experience. Run the Framework Advisor inline.
+
+Ask these 3 questions via AskUserQuestion, one at a time:
+
+### Q1: What data do you handle?
+
+> "What kind of data does your product handle?"
+>
+> - A) Patient or health data (names, diagnoses, prescriptions, medical records) → HIPAA
+> - B) Payment card data (credit card numbers, CVVs) → PCI-DSS
+> - C) Personal data of EU residents (names, emails, addresses of EU users) → GDPR
+> - D) General customer data (names, emails, usage data) → SOC 2
+
+### Q2: Who are your customers?
+
+> "Who are you selling to?"
+>
+> - A) Healthcare organizations → also add SOC 2 (enterprise health deals need both)
+> - B) Enterprise / B2B → also add SOC 2 if not already selected
+> - C) Consumers → no change
+> - D) Government → note NIST 800-53 direct mapping
+
+### Q3: Timeline pressure?
+
+> "What's driving your compliance timeline?"
+>
+> - A) A prospect or customer asked for it → prioritize that framework
+> - B) Proactive → start with the data-type framework
+> - C) An investor asked → SOC 2 first
+> - D) No specific pressure → start with the data-type framework
+
+### Output recommendation
+
+Based on answers, tell the user which frameworks they need NOW, LATER, and can SKIP.
+
+If multiple frameworks: "Good news: many controls overlap between frameworks. Do [primary] first and you'll have a head start on [secondary]."
+
+Initialize the recommended frameworks:
+```bash
+"$_EMDASH_BIN"/comply-db init --framework <primary>
+"$_EMDASH_BIN"/comply-db journey init --framework <primary>
+"$_EMDASH_BIN"/comply-db journey complete --milestone 1 --framework <primary>
+```
+
+Tell the user: **"Your next step is `/hipaa` (or whichever framework was recommended). It will walk you through an assessment of your stack."**
+
+## Step 4: If DB_EXISTS — Journey state routing
+
+```bash
+"$_EMDASH_BIN"/comply-db journey status 2>/dev/null || echo '{"initialized":false}'
+```
+
+### If journey not initialized (legacy user):
+
+Initialize and mark M1 complete (they already picked their framework):
+```bash
+"$_EMDASH_BIN"/comply-db journey init
+"$_EMDASH_BIN"/comply-db journey complete --milestone 1
+```
+
+### If journey in progress — route to current milestone:
+
+Read `current_milestone` from the JSON. Route based on milestone:
+
+- **M2 (Assessment & Scan):** "Run `/hipaa` (or your framework) to start the assessment interview and scan."
+- **M3 (Policy Generator):** "Run `/comply-policy` to generate personalized compliance policy documents."
+- **M4 (PR Gate Setup):** "Protect your compliance as you build. Run `bin/comply-check --diff HEAD~1` locally to check your code. To set up automated checking, add the em-dash GitHub Action."
+- **M5 (Trust Page):** "Generate a shareable compliance page for prospects. Run `/comply-report` with the trust page option."
+- **M6 (Deal Rescue):** "Got a security questionnaire from a prospect? Run `/comply-deal` to answer it."
+
+### If journey complete:
+
+Show summary and congratulate:
+```bash
+"$_EMDASH_BIN"/comply-db summary
+```
+
+"All milestones complete. Your compliance journey is done. Run `/comply-report` to generate your audit packet, or `/em-dashboard` for the visual view."
+
+## Step 5: Persona-aware status and recommendations
+
+Show current status:
 ```bash
 "$_EMDASH_BIN"/comply-db summary
 "$_EMDASH_BIN"/comply-db status
 ```
 
-Show which frameworks are active:
-```bash
-"$_EMDASH_BIN"/comply-db query "SELECT key, value FROM metadata WHERE key = 'framework'"
-```
+Read the persona and tailor recommendations:
 
-## Step 4: Recommend next step
+**Founder persona:**
+- Plain English descriptions. "You need to encrypt stored patient data" not "SC-28: Protection of Information at Rest"
+- Focus on journey milestones. "Your next milestone is generating policies."
+- Offer autopilot: "Want me to handle everything? I can scan your code, fix issues, and ask you questions one at a time."
 
-- **0% complete:** "Run `/comply-auto` to start."
-- **Some scans done:** "Run `/comply-assess` for interviews or `/comply-scan` for checks."
-- **Failures found:** "Run `/comply-fix` to remediate."
-- **Complete:** "Run `/comply-report` to generate your audit packet."
+**Engineer persona:**
+- Technical details. Control IDs, check results, specific file paths.
+- Action-oriented: "3 controls failing. Run `/comply-fix` to remediate." or "Run `/comply-scan` for a fresh check."
+- PR gate: "Run `bin/comply-check --diff HEAD~1` before pushing."
 
-Want to add another framework? Run `/soc2`, `/gdpr`, or `/pci-dss`.
-Want the visual dashboard? Run `/em-dashboard`.
+**Audit persona:**
+- Formal workflow focus. "Run `/comply-assess` for structured compliance interviews."
+- Reports: "Run `/comply-report` to generate your signed audit packet."
+- Simulation: "Run `/hipaa-audit` for a 7-phase mock HHS OCR audit."
+- Questionnaires: "Run `/comply-deal` to answer prospect security questionnaires."
+- Policies: "Run `/comply-policy` to generate or update compliance policy documents."
+
+## Always mention
+
+- Add frameworks: `/hipaa`, `/soc2`, `/gdpr`, `/pci-dss`
+- Visual dashboard: `/em-dashboard`
+- Breach response: `/comply-breach`
+- Check your code: `bin/comply-check --diff HEAD~1`

--- a/skills/gdpr/SKILL.md
+++ b/skills/gdpr/SKILL.md
@@ -1,10 +1,10 @@
 ---
 
 name: gdpr
-version: 2.0.0
+version: 3.0.0
 description: |
-  GDPR compliance. Initializes the framework, shows status,
-  and routes to comply-auto/scan/assess/fix/report skills.
+  GDPR compliance. Initializes the framework, asks domain-specific questions
+  about data processing role, lawful basis, and DPO status, then routes to comply skills.
 allowed-tools:
   - Bash
   - Read
@@ -20,32 +20,76 @@ allowed-tools:
 
 # /gdpr — GDPR Compliance
 
-Initialize GDPR compliance and show your status.
+Initialize GDPR compliance with domain-specific context.
 
-## Step 1: Initialize
+## Step 1: Initialize framework
 
 ```bash
 _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
 "$_EMDASH_BIN"/comply-db init --framework gdpr 2>/dev/null || true
+"$_EMDASH_BIN"/comply-db journey init 2>/dev/null || true
 "$_EMDASH_BIN"/comply-db summary
-"$_EMDASH_BIN"/comply-db status
 ```
 
 Tell the user: "GDPR compliance initialized. [N] NIST 800-53 controls imported."
 
-## Step 2: Recommend next step
+## Step 2: GDPR-specific questions
 
-- **0% complete:** "Run `/comply-auto` to start — it scans your infrastructure, fixes what it can, and asks you questions."
+Ask these via AskUserQuestion, one at a time:
+
+### Q1: Data processing role
+
+> "Under GDPR, are you a Controller or a Processor?"
+>
+> - A) Controller — we decide what data to collect and why (most SaaS companies)
+> - B) Processor — we process data on behalf of another company (B2B data services)
+> - C) Both — we have our own users AND process data for other companies
+> - D) Not sure
+
+### Q2: Data subject locations
+
+> "Where are your users/data subjects located?"
+>
+> - A) EU only
+> - B) EU + UK (need both GDPR and UK GDPR)
+> - C) Global (including EU residents)
+> - D) Not sure — we haven't tracked this yet
+
+### Q3: Lawful basis for processing
+
+> "What's your primary lawful basis for processing personal data?"
+>
+> - A) Consent — users explicitly agree (opt-in forms, cookie banners)
+> - B) Contract — processing is necessary to provide your service
+> - C) Legitimate Interest — you have a business reason and it doesn't override user rights
+> - D) Not sure — I need to figure this out
+
+### Q4: Data Protection Officer
+
+> "Do you have a Data Protection Officer (DPO)?"
+>
+> - A) Yes, we have a designated DPO
+> - B) No, but we plan to appoint one
+> - C) No — do I need one?
+
+If C: explain that a DPO is required if you process data on a large scale, handle special categories of data (health, biometric), or are a public authority.
+
+Store answers in metadata for context in assessments and reports.
+
+## Step 3: Recommend next step
+
+Based on progress:
+- **0% complete:** "Run `/comply` to start your compliance journey, or `/comply-auto` to scan everything."
 - **Partial:** "Run `/comply-assess` for interviews or `/comply-scan` for automated checks."
 - **Failures found:** "Run `/comply-fix` to remediate."
-- **Complete:** "Run `/comply-report` to generate your signed audit packet."
+- **Complete:** "Run `/comply-report` to generate your compliance report."
 
-## Step 3: Multiple frameworks
+## Step 4: Multiple frameworks
 
-If user wants to add another framework: "Run `/soc2`, `/gdpr`, or `/pci-dss` to add more. Controls are shared automatically."
+"Want to add another framework? Run `/hipaa`, `/soc2`, or `/pci-dss`. Controls are shared automatically."
 
 ## Important
 
 - All `/comply-*` skills work with whichever frameworks you've initialized.
 - Evidence lives in SQLite: `~/.em-dash/projects/{slug}/compliance.db`
-- EU data protection — privacy rights, data processing, breach notification
+- GDPR covers: data subject rights, lawful processing, breach notification (72 hours), DPO requirements

--- a/skills/gdpr/SKILL.md.tmpl
+++ b/skills/gdpr/SKILL.md.tmpl
@@ -1,10 +1,10 @@
 ---
 
 name: gdpr
-version: 2.0.0
+version: 3.0.0
 description: |
-  GDPR compliance. Initializes the framework, shows status,
-  and routes to comply-auto/scan/assess/fix/report skills.
+  GDPR compliance. Initializes the framework, asks domain-specific questions
+  about data processing role, lawful basis, and DPO status, then routes to comply skills.
 allowed-tools:
   - Bash
   - Read
@@ -18,32 +18,76 @@ allowed-tools:
 
 # /gdpr — GDPR Compliance
 
-Initialize GDPR compliance and show your status.
+Initialize GDPR compliance with domain-specific context.
 
-## Step 1: Initialize
+## Step 1: Initialize framework
 
 ```bash
 _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
 "$_EMDASH_BIN"/comply-db init --framework gdpr 2>/dev/null || true
+"$_EMDASH_BIN"/comply-db journey init 2>/dev/null || true
 "$_EMDASH_BIN"/comply-db summary
-"$_EMDASH_BIN"/comply-db status
 ```
 
 Tell the user: "GDPR compliance initialized. [N] NIST 800-53 controls imported."
 
-## Step 2: Recommend next step
+## Step 2: GDPR-specific questions
 
-- **0% complete:** "Run `/comply-auto` to start — it scans your infrastructure, fixes what it can, and asks you questions."
+Ask these via AskUserQuestion, one at a time:
+
+### Q1: Data processing role
+
+> "Under GDPR, are you a Controller or a Processor?"
+>
+> - A) Controller — we decide what data to collect and why (most SaaS companies)
+> - B) Processor — we process data on behalf of another company (B2B data services)
+> - C) Both — we have our own users AND process data for other companies
+> - D) Not sure
+
+### Q2: Data subject locations
+
+> "Where are your users/data subjects located?"
+>
+> - A) EU only
+> - B) EU + UK (need both GDPR and UK GDPR)
+> - C) Global (including EU residents)
+> - D) Not sure — we haven't tracked this yet
+
+### Q3: Lawful basis for processing
+
+> "What's your primary lawful basis for processing personal data?"
+>
+> - A) Consent — users explicitly agree (opt-in forms, cookie banners)
+> - B) Contract — processing is necessary to provide your service
+> - C) Legitimate Interest — you have a business reason and it doesn't override user rights
+> - D) Not sure — I need to figure this out
+
+### Q4: Data Protection Officer
+
+> "Do you have a Data Protection Officer (DPO)?"
+>
+> - A) Yes, we have a designated DPO
+> - B) No, but we plan to appoint one
+> - C) No — do I need one?
+
+If C: explain that a DPO is required if you process data on a large scale, handle special categories of data (health, biometric), or are a public authority.
+
+Store answers in metadata for context in assessments and reports.
+
+## Step 3: Recommend next step
+
+Based on progress:
+- **0% complete:** "Run `/comply` to start your compliance journey, or `/comply-auto` to scan everything."
 - **Partial:** "Run `/comply-assess` for interviews or `/comply-scan` for automated checks."
 - **Failures found:** "Run `/comply-fix` to remediate."
-- **Complete:** "Run `/comply-report` to generate your signed audit packet."
+- **Complete:** "Run `/comply-report` to generate your compliance report."
 
-## Step 3: Multiple frameworks
+## Step 4: Multiple frameworks
 
-If user wants to add another framework: "Run `/soc2`, `/gdpr`, or `/pci-dss` to add more. Controls are shared automatically."
+"Want to add another framework? Run `/hipaa`, `/soc2`, or `/pci-dss`. Controls are shared automatically."
 
 ## Important
 
 - All `/comply-*` skills work with whichever frameworks you've initialized.
 - Evidence lives in SQLite: `~/.em-dash/projects/{slug}/compliance.db`
-- EU data protection — privacy rights, data processing, breach notification
+- GDPR covers: data subject rights, lawful processing, breach notification (72 hours), DPO requirements

--- a/skills/hipaa/SKILL.md
+++ b/skills/hipaa/SKILL.md
@@ -4,7 +4,7 @@ name: hipaa
 version: 2.0.0
 description: |
   HIPAA compliance. Initializes the framework, shows status,
-  and routes to comply-auto/scan/assess/fix/report skills.
+  and routes to comply/scan/assess/fix/report skills.
 allowed-tools:
   - Bash
   - Read
@@ -35,7 +35,7 @@ Tell the user: "HIPAA compliance initialized. [N] NIST 800-53 controls imported.
 
 ## Step 2: Recommend next step
 
-- **0% complete:** "Run `/comply-auto` to start — it scans your infrastructure, fixes what it can, and asks you questions."
+- **0% complete:** "Run `/comply` to start your compliance journey — it guides you through everything step by step."
 - **Partial:** "Run `/comply-assess` for interviews or `/comply-scan` for automated checks."
 - **Failures found:** "Run `/comply-fix` to remediate."
 - **Complete:** "Run `/comply-report` to generate your signed audit packet."

--- a/skills/hipaa/SKILL.md.tmpl
+++ b/skills/hipaa/SKILL.md.tmpl
@@ -4,7 +4,7 @@ name: hipaa
 version: 2.0.0
 description: |
   HIPAA compliance. Initializes the framework, shows status,
-  and routes to comply-auto/scan/assess/fix/report skills.
+  and routes to comply/scan/assess/fix/report skills.
 allowed-tools:
   - Bash
   - Read
@@ -33,7 +33,7 @@ Tell the user: "HIPAA compliance initialized. [N] NIST 800-53 controls imported.
 
 ## Step 2: Recommend next step
 
-- **0% complete:** "Run `/comply-auto` to start — it scans your infrastructure, fixes what it can, and asks you questions."
+- **0% complete:** "Run `/comply` to start your compliance journey — it guides you through everything step by step."
 - **Partial:** "Run `/comply-assess` for interviews or `/comply-scan` for automated checks."
 - **Failures found:** "Run `/comply-fix` to remediate."
 - **Complete:** "Run `/comply-report` to generate your signed audit packet."

--- a/skills/pci-dss/SKILL.md
+++ b/skills/pci-dss/SKILL.md
@@ -1,10 +1,10 @@
 ---
 
 name: pci-dss
-version: 2.0.0
+version: 3.0.0
 description: |
-  PCI-DSS compliance. Initializes the framework, shows status,
-  and routes to comply-auto/scan/assess/fix/report skills.
+  PCI-DSS compliance. Initializes the framework, asks domain-specific questions
+  about cardholder data environment and SAQ type, then routes to comply skills.
 allowed-tools:
   - Bash
   - Read
@@ -20,32 +20,70 @@ allowed-tools:
 
 # /pci-dss — PCI-DSS Compliance
 
-Initialize PCI-DSS compliance and show your status.
+Initialize PCI-DSS compliance with domain-specific context.
 
-## Step 1: Initialize
+## Step 1: Initialize framework
 
 ```bash
 _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
 "$_EMDASH_BIN"/comply-db init --framework pci-dss 2>/dev/null || true
+"$_EMDASH_BIN"/comply-db journey init 2>/dev/null || true
 "$_EMDASH_BIN"/comply-db summary
-"$_EMDASH_BIN"/comply-db status
 ```
 
 Tell the user: "PCI-DSS compliance initialized. [N] NIST 800-53 controls imported."
 
-## Step 2: Recommend next step
+## Step 2: PCI-DSS-specific questions
 
-- **0% complete:** "Run `/comply-auto` to start — it scans your infrastructure, fixes what it can, and asks you questions."
+Ask these via AskUserQuestion, one at a time:
+
+### Q1: Cardholder data handling
+
+> "How does your application handle payment card data?"
+>
+> - A) We use a payment processor (Stripe, Square, Braintree) and never see card numbers
+> - B) We handle card data through a hosted payment page (iframe/redirect)
+> - C) We directly store, process, or transmit card numbers in our systems
+> - D) Not sure
+
+If A: "Using a payment processor significantly reduces your PCI scope. You'll likely qualify for SAQ A (simplest). Most controls are inherited from your processor."
+
+### Q2: Cardholder data environment scope
+
+> "What systems touch payment data in your environment?"
+>
+> - A) Just the payment processor integration (API calls only)
+> - B) Our web servers handle payment forms, but we don't store card data
+> - C) We store card data in our database
+> - D) Card data flows through multiple systems
+
+### Q3: SAQ type
+
+> "Which PCI-DSS Self-Assessment Questionnaire type applies to you?"
+>
+> - A) SAQ A — card-not-present, fully outsourced (e-commerce with hosted payment page)
+> - B) SAQ A-EP — card-not-present, partially outsourced (e-commerce with redirect)
+> - C) SAQ D — all other merchants / service providers
+> - D) I'm not sure which SAQ applies
+
+If D: Based on Q1 and Q2 answers, recommend the likely SAQ type.
+
+Store answers in metadata for context in assessments and reports.
+
+## Step 3: Recommend next step
+
+Based on progress:
+- **0% complete:** "Run `/comply` to start your compliance journey, or `/comply-auto` to scan everything."
 - **Partial:** "Run `/comply-assess` for interviews or `/comply-scan` for automated checks."
 - **Failures found:** "Run `/comply-fix` to remediate."
-- **Complete:** "Run `/comply-report` to generate your signed audit packet."
+- **Complete:** "Run `/comply-report` to generate your compliance report."
 
-## Step 3: Multiple frameworks
+## Step 4: Multiple frameworks
 
-If user wants to add another framework: "Run `/soc2`, `/gdpr`, or `/pci-dss` to add more. Controls are shared automatically."
+"Want to add another framework? Run `/hipaa`, `/soc2`, or `/gdpr`. Controls are shared automatically."
 
 ## Important
 
 - All `/comply-*` skills work with whichever frameworks you've initialized.
 - Evidence lives in SQLite: `~/.em-dash/projects/{slug}/compliance.db`
-- Payment card data security — cardholder data protection
+- PCI-DSS covers: cardholder data protection, network security, access control, monitoring

--- a/skills/pci-dss/SKILL.md.tmpl
+++ b/skills/pci-dss/SKILL.md.tmpl
@@ -1,10 +1,10 @@
 ---
 
 name: pci-dss
-version: 2.0.0
+version: 3.0.0
 description: |
-  PCI-DSS compliance. Initializes the framework, shows status,
-  and routes to comply-auto/scan/assess/fix/report skills.
+  PCI-DSS compliance. Initializes the framework, asks domain-specific questions
+  about cardholder data environment and SAQ type, then routes to comply skills.
 allowed-tools:
   - Bash
   - Read
@@ -18,32 +18,70 @@ allowed-tools:
 
 # /pci-dss — PCI-DSS Compliance
 
-Initialize PCI-DSS compliance and show your status.
+Initialize PCI-DSS compliance with domain-specific context.
 
-## Step 1: Initialize
+## Step 1: Initialize framework
 
 ```bash
 _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
 "$_EMDASH_BIN"/comply-db init --framework pci-dss 2>/dev/null || true
+"$_EMDASH_BIN"/comply-db journey init 2>/dev/null || true
 "$_EMDASH_BIN"/comply-db summary
-"$_EMDASH_BIN"/comply-db status
 ```
 
 Tell the user: "PCI-DSS compliance initialized. [N] NIST 800-53 controls imported."
 
-## Step 2: Recommend next step
+## Step 2: PCI-DSS-specific questions
 
-- **0% complete:** "Run `/comply-auto` to start — it scans your infrastructure, fixes what it can, and asks you questions."
+Ask these via AskUserQuestion, one at a time:
+
+### Q1: Cardholder data handling
+
+> "How does your application handle payment card data?"
+>
+> - A) We use a payment processor (Stripe, Square, Braintree) and never see card numbers
+> - B) We handle card data through a hosted payment page (iframe/redirect)
+> - C) We directly store, process, or transmit card numbers in our systems
+> - D) Not sure
+
+If A: "Using a payment processor significantly reduces your PCI scope. You'll likely qualify for SAQ A (simplest). Most controls are inherited from your processor."
+
+### Q2: Cardholder data environment scope
+
+> "What systems touch payment data in your environment?"
+>
+> - A) Just the payment processor integration (API calls only)
+> - B) Our web servers handle payment forms, but we don't store card data
+> - C) We store card data in our database
+> - D) Card data flows through multiple systems
+
+### Q3: SAQ type
+
+> "Which PCI-DSS Self-Assessment Questionnaire type applies to you?"
+>
+> - A) SAQ A — card-not-present, fully outsourced (e-commerce with hosted payment page)
+> - B) SAQ A-EP — card-not-present, partially outsourced (e-commerce with redirect)
+> - C) SAQ D — all other merchants / service providers
+> - D) I'm not sure which SAQ applies
+
+If D: Based on Q1 and Q2 answers, recommend the likely SAQ type.
+
+Store answers in metadata for context in assessments and reports.
+
+## Step 3: Recommend next step
+
+Based on progress:
+- **0% complete:** "Run `/comply` to start your compliance journey, or `/comply-auto` to scan everything."
 - **Partial:** "Run `/comply-assess` for interviews or `/comply-scan` for automated checks."
 - **Failures found:** "Run `/comply-fix` to remediate."
-- **Complete:** "Run `/comply-report` to generate your signed audit packet."
+- **Complete:** "Run `/comply-report` to generate your compliance report."
 
-## Step 3: Multiple frameworks
+## Step 4: Multiple frameworks
 
-If user wants to add another framework: "Run `/soc2`, `/gdpr`, or `/pci-dss` to add more. Controls are shared automatically."
+"Want to add another framework? Run `/hipaa`, `/soc2`, or `/gdpr`. Controls are shared automatically."
 
 ## Important
 
 - All `/comply-*` skills work with whichever frameworks you've initialized.
 - Evidence lives in SQLite: `~/.em-dash/projects/{slug}/compliance.db`
-- Payment card data security — cardholder data protection
+- PCI-DSS covers: cardholder data protection, network security, access control, monitoring

--- a/skills/soc2/SKILL.md
+++ b/skills/soc2/SKILL.md
@@ -1,10 +1,10 @@
 ---
 
 name: soc2
-version: 2.0.0
+version: 3.0.0
 description: |
-  SOC 2 compliance. Initializes the framework, shows status,
-  and routes to comply-auto/scan/assess/fix/report skills.
+  SOC 2 compliance. Initializes the framework, asks domain-specific questions
+  about trust service criteria and audit type, then routes to comply skills.
 allowed-tools:
   - Bash
   - Read
@@ -20,32 +20,65 @@ allowed-tools:
 
 # /soc2 — SOC 2 Compliance
 
-Initialize SOC 2 compliance and show your status.
+Initialize SOC 2 compliance with domain-specific context.
 
-## Step 1: Initialize
+## Step 1: Initialize framework
 
 ```bash
 _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
 "$_EMDASH_BIN"/comply-db init --framework soc2 2>/dev/null || true
+"$_EMDASH_BIN"/comply-db journey init 2>/dev/null || true
 "$_EMDASH_BIN"/comply-db summary
-"$_EMDASH_BIN"/comply-db status
 ```
 
 Tell the user: "SOC 2 compliance initialized. [N] NIST 800-53 controls imported."
 
-## Step 2: Recommend next step
+## Step 2: SOC 2-specific questions
 
-- **0% complete:** "Run `/comply-auto` to start — it scans your infrastructure, fixes what it can, and asks you questions."
+Ask these via AskUserQuestion, one at a time:
+
+### Q1: Trust Service Criteria
+
+> "Which SOC 2 Trust Service Criteria matter for your customers?"
+>
+> - A) Security only (most common for startups)
+> - B) Security + Availability (SaaS with uptime SLAs)
+> - C) Security + Confidentiality (handling sensitive data)
+> - D) All five (Security, Availability, Confidentiality, Processing Integrity, Privacy)
+
+### Q2: Audit type
+
+> "Are you pursuing a Type I or Type II audit?"
+>
+> - A) Type I — point-in-time assessment (faster, cheaper, good for first audit)
+> - B) Type II — over a review period, typically 6-12 months (stronger, required by most enterprises)
+> - C) Not sure yet
+
+### Q3: Primary driver
+
+> "What's driving your SOC 2 effort?"
+>
+> - A) A prospect or customer requires it to close a deal
+> - B) We want to sell to enterprises and need it proactively
+> - C) An investor asked about it
+> - D) Internal security improvement
+
+Store answers in metadata for context in assessments and reports.
+
+## Step 3: Recommend next step
+
+Based on progress:
+- **0% complete:** "Run `/comply` to start your compliance journey, or `/comply-auto` to scan everything."
 - **Partial:** "Run `/comply-assess` for interviews or `/comply-scan` for automated checks."
 - **Failures found:** "Run `/comply-fix` to remediate."
 - **Complete:** "Run `/comply-report` to generate your signed audit packet."
 
-## Step 3: Multiple frameworks
+## Step 4: Multiple frameworks
 
-If user wants to add another framework: "Run `/soc2`, `/gdpr`, or `/pci-dss` to add more. Controls are shared automatically."
+"Want to add another framework? Run `/hipaa`, `/gdpr`, or `/pci-dss`. Controls are shared automatically."
 
 ## Important
 
 - All `/comply-*` skills work with whichever frameworks you've initialized.
 - Evidence lives in SQLite: `~/.em-dash/projects/{slug}/compliance.db`
-- SaaS trust service criteria — security, availability, confidentiality
+- SOC 2 covers Trust Service Criteria: Security, Availability, Confidentiality, Processing Integrity, Privacy

--- a/skills/soc2/SKILL.md.tmpl
+++ b/skills/soc2/SKILL.md.tmpl
@@ -1,10 +1,10 @@
 ---
 
 name: soc2
-version: 2.0.0
+version: 3.0.0
 description: |
-  SOC 2 compliance. Initializes the framework, shows status,
-  and routes to comply-auto/scan/assess/fix/report skills.
+  SOC 2 compliance. Initializes the framework, asks domain-specific questions
+  about trust service criteria and audit type, then routes to comply skills.
 allowed-tools:
   - Bash
   - Read
@@ -18,32 +18,65 @@ allowed-tools:
 
 # /soc2 — SOC 2 Compliance
 
-Initialize SOC 2 compliance and show your status.
+Initialize SOC 2 compliance with domain-specific context.
 
-## Step 1: Initialize
+## Step 1: Initialize framework
 
 ```bash
 _EMDASH_BIN=$([ -d ~/.claude/skills/em-dash/bin ] && echo ~/.claude/skills/em-dash/bin || echo .claude/skills/em-dash/bin)
 "$_EMDASH_BIN"/comply-db init --framework soc2 2>/dev/null || true
+"$_EMDASH_BIN"/comply-db journey init 2>/dev/null || true
 "$_EMDASH_BIN"/comply-db summary
-"$_EMDASH_BIN"/comply-db status
 ```
 
 Tell the user: "SOC 2 compliance initialized. [N] NIST 800-53 controls imported."
 
-## Step 2: Recommend next step
+## Step 2: SOC 2-specific questions
 
-- **0% complete:** "Run `/comply-auto` to start — it scans your infrastructure, fixes what it can, and asks you questions."
+Ask these via AskUserQuestion, one at a time:
+
+### Q1: Trust Service Criteria
+
+> "Which SOC 2 Trust Service Criteria matter for your customers?"
+>
+> - A) Security only (most common for startups)
+> - B) Security + Availability (SaaS with uptime SLAs)
+> - C) Security + Confidentiality (handling sensitive data)
+> - D) All five (Security, Availability, Confidentiality, Processing Integrity, Privacy)
+
+### Q2: Audit type
+
+> "Are you pursuing a Type I or Type II audit?"
+>
+> - A) Type I — point-in-time assessment (faster, cheaper, good for first audit)
+> - B) Type II — over a review period, typically 6-12 months (stronger, required by most enterprises)
+> - C) Not sure yet
+
+### Q3: Primary driver
+
+> "What's driving your SOC 2 effort?"
+>
+> - A) A prospect or customer requires it to close a deal
+> - B) We want to sell to enterprises and need it proactively
+> - C) An investor asked about it
+> - D) Internal security improvement
+
+Store answers in metadata for context in assessments and reports.
+
+## Step 3: Recommend next step
+
+Based on progress:
+- **0% complete:** "Run `/comply` to start your compliance journey, or `/comply-auto` to scan everything."
 - **Partial:** "Run `/comply-assess` for interviews or `/comply-scan` for automated checks."
 - **Failures found:** "Run `/comply-fix` to remediate."
 - **Complete:** "Run `/comply-report` to generate your signed audit packet."
 
-## Step 3: Multiple frameworks
+## Step 4: Multiple frameworks
 
-If user wants to add another framework: "Run `/soc2`, `/gdpr`, or `/pci-dss` to add more. Controls are shared automatically."
+"Want to add another framework? Run `/hipaa`, `/gdpr`, or `/pci-dss`. Controls are shared automatically."
 
 ## Important
 
 - All `/comply-*` skills work with whichever frameworks you've initialized.
 - Evidence lives in SQLite: `~/.em-dash/projects/{slug}/compliance.db`
-- SaaS trust service criteria — security, availability, confidentiality
+- SOC 2 covers Trust Service Criteria: Security, Availability, Confidentiality, Processing Integrity, Privacy

--- a/test/architecture.test.ts
+++ b/test/architecture.test.ts
@@ -546,14 +546,14 @@ describe("Signing & Verification", () => {
 
 // ═══ Skills ═════════════════════════════════════════════════
 
-describe("Skills (14 total)", () => {
-	test("exactly 14 skill directories", () => {
+describe("Skills (16 total)", () => {
+	test("exactly 16 skill directories", () => {
 		const skills = fs
 			.readdirSync(path.join(ROOT, "skills"))
 			.filter((d: string) =>
 				fs.statSync(path.join(ROOT, "skills", d)).isDirectory(),
 			);
-		expect(skills.length).toBe(14);
+		expect(skills.length).toBe(16);
 	});
 
 	test("expected skills present", () => {
@@ -562,8 +562,10 @@ describe("Skills (14 total)", () => {
 			"comply-assess",
 			"comply-auto",
 			"comply-breach",
+			"comply-deal",
 			"comply-explain",
 			"comply-fix",
+			"comply-policy",
 			"comply-report",
 			"comply-scan",
 			"em-dashboard",

--- a/test/architecture.test.ts
+++ b/test/architecture.test.ts
@@ -546,36 +546,30 @@ describe("Signing & Verification", () => {
 
 // ═══ Skills ═════════════════════════════════════════════════
 
-describe("Skills (20 total)", () => {
-	test("exactly 20 skill directories", () => {
+describe("Skills (14 total)", () => {
+	test("exactly 14 skill directories", () => {
 		const skills = fs
 			.readdirSync(path.join(ROOT, "skills"))
 			.filter((d: string) =>
 				fs.statSync(path.join(ROOT, "skills", d)).isDirectory(),
 			);
-		expect(skills.length).toBe(20);
+		expect(skills.length).toBe(14);
 	});
 
 	test("expected skills present", () => {
 		const expected = [
 			"comply",
-			"comply-auto",
 			"comply-assess",
-			"comply-audit",
+			"comply-auto",
 			"comply-breach",
-			"comply-deal",
 			"comply-explain",
 			"comply-fix",
-			"comply-monitor",
-			"comply-policy",
 			"comply-report",
 			"comply-scan",
-			"cis",
 			"em-dashboard",
 			"gdpr",
 			"hipaa",
 			"hipaa-audit",
-			"iso27001",
 			"pci-dss",
 			"soc2",
 		];
@@ -607,6 +601,7 @@ describe("Skills (20 total)", () => {
 		const removed = [
 			"comply-vendor",
 			"comply-risk",
+			"comply-monitor",
 			"comply-oscal-import",
 			"comply-verify",
 			"comply-remediate",

--- a/test/architecture.test.ts
+++ b/test/architecture.test.ts
@@ -546,14 +546,14 @@ describe("Signing & Verification", () => {
 
 // ═══ Skills ═════════════════════════════════════════════════
 
-describe("Skills (13 total)", () => {
-	test("exactly 13 skill directories", () => {
+describe("Skills (20 total)", () => {
+	test("exactly 20 skill directories", () => {
 		const skills = fs
 			.readdirSync(path.join(ROOT, "skills"))
 			.filter((d: string) =>
 				fs.statSync(path.join(ROOT, "skills", d)).isDirectory(),
 			);
-		expect(skills.length).toBe(13);
+		expect(skills.length).toBe(20);
 	});
 
 	test("expected skills present", () => {
@@ -561,16 +561,23 @@ describe("Skills (13 total)", () => {
 			"comply",
 			"comply-auto",
 			"comply-assess",
-			"comply-scan",
-			"comply-fix",
-			"comply-report",
+			"comply-audit",
 			"comply-breach",
+			"comply-deal",
+			"comply-explain",
+			"comply-fix",
+			"comply-monitor",
+			"comply-policy",
+			"comply-report",
+			"comply-scan",
+			"cis",
 			"em-dashboard",
+			"gdpr",
 			"hipaa",
 			"hipaa-audit",
-			"soc2",
-			"gdpr",
+			"iso27001",
 			"pci-dss",
+			"soc2",
 		];
 		const skills = fs
 			.readdirSync(path.join(ROOT, "skills"))
@@ -600,7 +607,6 @@ describe("Skills (13 total)", () => {
 		const removed = [
 			"comply-vendor",
 			"comply-risk",
-			"comply-monitor",
 			"comply-oscal-import",
 			"comply-verify",
 			"comply-remediate",

--- a/test/bin-smoke.test.ts
+++ b/test/bin-smoke.test.ts
@@ -258,6 +258,185 @@ describe("Bin smoke: comply-db control --json", () => {
 	});
 });
 
+describe("Bin smoke: comply-db control --json invalid ID", () => {
+	let tmpDir: string;
+
+	beforeAll(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "emdash-invalid-"));
+		await run("comply-db", ["init", "--framework", "hipaa"], { cwd: tmpDir });
+	});
+
+	afterAll(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("--json mode errors on invalid control ID", async () => {
+		const { stderr, exitCode } = await run(
+			"comply-db",
+			["control", "FAKE-99", "--json", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("not found");
+	});
+
+	test("lowercase IDs still resolve correctly", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["control", "sc-28", "--json", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.control_id).toBe("SC-28");
+		expect(data.plain_english).toBeDefined();
+		expect(data.why_it_matters).toBeDefined();
+	});
+});
+
+describe("Bin smoke: comply-db journey", () => {
+	let tmpDir: string;
+
+	beforeAll(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "emdash-journey-"));
+		await run("comply-db", ["init", "--framework", "hipaa"], { cwd: tmpDir });
+	});
+
+	afterAll(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("journey init seeds milestones", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["journey", "init", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.action).toBe("initialized");
+		expect(data.milestones).toBe(6);
+	});
+
+	test("journey init is idempotent", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["journey", "init", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.action).toBe("already_initialized");
+	});
+
+	test("journey status shows current milestone", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["journey", "status", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.initialized).toBe(true);
+		expect(data.current_milestone.id).toBe(1);
+		expect(data.current_milestone.status).toBe("AVAILABLE");
+		expect(data.complete).toBe(false);
+	});
+
+	test("journey complete unlocks next milestone", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["journey", "complete", "--milestone", "1", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.action).toBe("complete");
+		expect(data.status).toBe("COMPLETE");
+		expect(data.next_unlocked).toBe(2);
+	});
+
+	test("journey skip sets SKIPPED status", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["journey", "skip", "--milestone", "2", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.action).toBe("skip");
+		expect(data.status).toBe("SKIPPED");
+	});
+
+	test("journey status skips over SKIPPED milestones", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["journey", "status", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.current_milestone.id).toBe(3);
+	});
+});
+
+describe("Bin smoke: comply-db config", () => {
+	let tmpDir: string;
+	let configPath: string;
+
+	beforeAll(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "emdash-config-"));
+		configPath = path.join(tmpDir, "config.json");
+	});
+
+	afterAll(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("config set saves valid key", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["config", "set", "persona", "founder"],
+			{ cwd: tmpDir, env: { ...process.env, HOME: tmpDir } },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.action).toBe("set");
+		expect(data.key).toBe("persona");
+		expect(data.value).toBe("founder");
+	});
+
+	test("config get retrieves saved value", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["config", "get", "persona"],
+			{ cwd: tmpDir, env: { ...process.env, HOME: tmpDir } },
+		);
+		expect(exitCode).toBe(0);
+		expect(stdout.trim()).toBe("founder");
+	});
+
+	test("config set rejects unknown key", async () => {
+		const { stderr, exitCode } = await run(
+			"comply-db",
+			["config", "set", "typo_key", "value"],
+			{ cwd: tmpDir, env: { ...process.env, HOME: tmpDir } },
+		);
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("Unknown config key");
+	});
+
+	test("config set rejects invalid value for known key", async () => {
+		const { stderr, exitCode } = await run(
+			"comply-db",
+			["config", "set", "persona", "invalid"],
+			{ cwd: tmpDir, env: { ...process.env, HOME: tmpDir } },
+		);
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("Invalid value");
+	});
+});
+
 describe("Bin smoke: hipaa-evidence-hash", () => {
 	let tmpDir: string;
 

--- a/test/bin-smoke.test.ts
+++ b/test/bin-smoke.test.ts
@@ -173,6 +173,91 @@ describe("Bin smoke: comply-db update-scan", () => {
 	});
 });
 
+describe("Bin smoke: comply-db control --json", () => {
+	let tmpDir: string;
+
+	beforeAll(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "emdash-explain-"));
+		await run("comply-db", ["init", "--framework", "hipaa"], { cwd: tmpDir });
+	});
+
+	afterAll(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("outputs valid JSON with enriched fields for SC-28", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["control", "SC-28", "--json", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.control_id).toBe("SC-28");
+		expect(data.nist_name).toBeDefined();
+		expect(data.family).toBeDefined();
+		expect(data.plain_english).toBeDefined();
+		expect(data.why_it_matters).toBeDefined();
+		expect(data.nist_guidance).toBeDefined();
+		expect(data.hipaa_sections).toBeInstanceOf(Array);
+		expect(data.hipaa_sections.length).toBeGreaterThan(0);
+		expect(data.related_controls).toBeInstanceOf(Array);
+		expect(data.related_controls.length).toBeGreaterThan(0);
+		expect(data.verification).toBeDefined();
+		expect(data.verification.automated).toBe(true);
+		expect(data._sources).toBeDefined();
+		expect(data._sources.nist_catalog).toBe("found");
+		expect(data._sources.plain_english).toBe("found");
+	});
+
+	test("resolves HIPAA CFR section to NIST control", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["control", "164.312(a)(2)(iv)", "--json", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		// 164.312(a)(2)(iv) maps to SC-28
+		expect(data.control_id).toBe("SC-28");
+		expect(data.resolved_from).toBe("164.312(a)(2)(iv)");
+	});
+
+	test("--simple flag sets eli5_requested", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["control", "SC-28", "--json", "--simple", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.eli5_requested).toBe(true);
+	});
+
+	test("returns error for invalid control ID", async () => {
+		const { stderr, exitCode } = await run(
+			"comply-db",
+			["control", "FAKE-99", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("not found");
+	});
+
+	test("interview-only control has interview_only flag", async () => {
+		const { stdout, exitCode } = await run(
+			"comply-db",
+			["control", "AC-4", "--json", "--framework", "hipaa"],
+			{ cwd: tmpDir },
+		);
+		expect(exitCode).toBe(0);
+		const data = JSON.parse(stdout);
+		expect(data.verification).toBeDefined();
+		expect(data.verification.interview_only).toBe(true);
+		expect(data.verification.automated).toBe(false);
+	});
+});
+
 describe("Bin smoke: hipaa-evidence-hash", () => {
 	let tmpDir: string;
 

--- a/test/plain-english.test.ts
+++ b/test/plain-english.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Plain-English Control Translations Tests
+ *
+ * Validates that nist/plain-english.json:
+ * - Covers all HIPAA-mapped NIST 800-53 controls
+ * - Has well-formed entries with required fields
+ * - Contains no orphaned entries
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const NIST = path.join(ROOT, "nist");
+
+const plainEnglish: Record<
+	string,
+	{ nist_name: string; plain_english: string; why_it_matters: string }
+> = JSON.parse(fs.readFileSync(path.join(NIST, "plain-english.json"), "utf-8"));
+
+const hipaaFilter: { mapping: Record<string, string[]> } = JSON.parse(
+	fs.readFileSync(path.join(NIST, "hipaa-filter.json"), "utf-8"),
+);
+
+// Extract all unique NIST control IDs from hipaa-filter
+const allControlIds = new Set<string>();
+for (const ids of Object.values(hipaaFilter.mapping)) {
+	for (const id of ids) allControlIds.add(id);
+}
+
+describe("Plain-English control translations", () => {
+	test("has entries for all HIPAA-mapped NIST controls", () => {
+		const missing: string[] = [];
+		for (const id of allControlIds) {
+			if (!plainEnglish[id]) missing.push(id);
+		}
+		expect(missing).toEqual([]);
+	});
+
+	test("has exactly 59 entries", () => {
+		expect(Object.keys(plainEnglish).length).toBe(59);
+	});
+
+	test("every entry has required fields", () => {
+		for (const [_id, entry] of Object.entries(plainEnglish)) {
+			expect(entry.nist_name).toBeDefined();
+			expect(entry.plain_english).toBeDefined();
+			expect(entry.why_it_matters).toBeDefined();
+			expect(typeof entry.nist_name).toBe("string");
+			expect(typeof entry.plain_english).toBe("string");
+			expect(typeof entry.why_it_matters).toBe("string");
+			expect(entry.nist_name.length).toBeGreaterThan(0);
+			expect(entry.plain_english.length).toBeGreaterThan(0);
+			expect(entry.why_it_matters.length).toBeGreaterThan(0);
+		}
+	});
+
+	test("no orphaned entries", () => {
+		const orphans: string[] = [];
+		for (const id of Object.keys(plainEnglish)) {
+			if (!allControlIds.has(id)) orphans.push(id);
+		}
+		expect(orphans).toEqual([]);
+	});
+
+	test("plain_english field is rewritten, not copied from NIST name", () => {
+		for (const [_id, entry] of Object.entries(plainEnglish)) {
+			expect(entry.plain_english).not.toBe(entry.nist_name);
+			expect(entry.plain_english.toLowerCase()).not.toStartWith(
+				entry.nist_name.toLowerCase(),
+			);
+		}
+	});
+});
+
+// ═══ NIST catalog data availability for explain enrichment ═══
+
+const nistCatalog = JSON.parse(
+	fs.readFileSync(
+		path.join(NIST, "NIST_SP-800-53_rev5_catalog.json"),
+		"utf-8",
+	),
+);
+
+const toolBindings = JSON.parse(
+	fs.readFileSync(path.join(NIST, "tool-bindings.json"), "utf-8"),
+);
+
+describe("NIST catalog data for explain enrichment", () => {
+	const TOOL_KEYS = ["emdash", "prowler", "checkov", "trivy", "lynis"];
+
+	function findControl(catalog: any, controlId: string) {
+		const id = controlId.toLowerCase();
+		for (const group of catalog.catalog.groups) {
+			for (const ctrl of group.controls || []) {
+				if (ctrl.id === id) return ctrl;
+				for (const enh of ctrl.controls || []) {
+					if (enh.id === id) return enh;
+				}
+			}
+		}
+		return null;
+	}
+
+	test("every HIPAA control exists in the NIST catalog", () => {
+		const missing: string[] = [];
+		for (const id of allControlIds) {
+			if (!findControl(nistCatalog, id)) missing.push(id);
+		}
+		expect(missing).toEqual([]);
+	});
+
+	test("related control links resolve to valid control IDs", () => {
+		const badLinks: string[] = [];
+		for (const id of allControlIds) {
+			const ctrl = findControl(nistCatalog, id);
+			if (!ctrl) continue;
+			for (const link of ctrl.links || []) {
+				if (link.rel === "related") {
+					const refId = link.href.replace("#", "").toLowerCase();
+					if (!findControl(nistCatalog, refId)) {
+						badLinks.push(`${id} -> ${link.href}`);
+					}
+				}
+			}
+		}
+		expect(badLinks).toEqual([]);
+	});
+
+	test("tool bindings use expected key types", () => {
+		for (const [_controlId, binding] of Object.entries(
+			toolBindings.bindings,
+		)) {
+			const b = binding as any;
+			for (const key of TOOL_KEYS) {
+				if (b[key] !== undefined) {
+					expect(Array.isArray(b[key])).toBe(true);
+				}
+			}
+			if (b.interview_only !== undefined) {
+				expect(typeof b.interview_only).toBe("boolean");
+			}
+			if (b.description !== undefined) {
+				expect(typeof b.description).toBe("string");
+			}
+		}
+	});
+});

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -36,8 +36,8 @@ function findGenerated(): string[] {
 describe("Skill template validation", () => {
 	const templates = findTemplates();
 
-	test("14 skill templates exist", () => {
-		expect(templates.length).toBe(14);
+	test("16 skill templates exist", () => {
+		expect(templates.length).toBe(16);
 	});
 
 	for (const tmpl of templates) {
@@ -60,8 +60,8 @@ describe("Skill template validation", () => {
 describe("Generated SKILL.md files", () => {
 	const generated = findGenerated();
 
-	test("14 generated files exist", () => {
-		expect(generated.length).toBe(14);
+	test("16 generated files exist", () => {
+		expect(generated.length).toBe(16);
 	});
 
 	for (const md of generated) {

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -36,8 +36,8 @@ function findGenerated(): string[] {
 describe("Skill template validation", () => {
 	const templates = findTemplates();
 
-	test("13 skill templates exist", () => {
-		expect(templates.length).toBe(13);
+	test("20 skill templates exist", () => {
+		expect(templates.length).toBe(20);
 	});
 
 	for (const tmpl of templates) {
@@ -60,8 +60,8 @@ describe("Skill template validation", () => {
 describe("Generated SKILL.md files", () => {
 	const generated = findGenerated();
 
-	test("13 generated files exist", () => {
-		expect(generated.length).toBe(13);
+	test("14 generated files exist", () => {
+		expect(generated.length).toBe(14);
 	});
 
 	for (const md of generated) {

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -36,8 +36,8 @@ function findGenerated(): string[] {
 describe("Skill template validation", () => {
 	const templates = findTemplates();
 
-	test("20 skill templates exist", () => {
-		expect(templates.length).toBe(20);
+	test("14 skill templates exist", () => {
+		expect(templates.length).toBe(14);
 	});
 
 	for (const tmpl of templates) {


### PR DESCRIPTION
## Summary

- **/comply v3.0** rewritten as a journey engine: persona detection (founder/engineer/audit), Framework Advisor with 3 guided questions, 6-milestone routing, and persona-aware recommendations
- **bin/comply-check** new PR gate CLI that checks git diffs for PHI patterns, sensitive data exposure, removed security controls, and BAA-requiring dependencies (exit 0/1/2)
- **/comply-policy** and **/comply-deal** new skills for generating personalized policy documents and answering prospect security questionnaires
- **/soc2**, **/gdpr**, **/pci-dss** enhanced with domain-specific onboarding questions (trust criteria, GDPR roles, SAQ types)
- **/comply-auto** deprecated with wrapper pointing to /comply Autopilot mode
- **nist/baa-vendors.json** curated list of 13 services requiring Business Associate Agreements

## Test plan

- [x] `bun test test/architecture.test.ts` — skill count updated 14 → 16, new skills in expected array
- [x] `bun test test/skill-validation.test.ts` — template and generated file counts updated
- [x] `bun run gen:skill-docs` — all 16 skills regenerate cleanly
- [x] `bin/comply-check --diff HEAD~1 --json` — returns findings JSON with severity classification
- [ ] Manual: run `/comply` in Claude Code, verify persona prompt and journey routing
- [ ] Manual: run `/comply-deal`, verify questionnaire parsing flow
- [ ] Manual: run `/comply-policy`, verify policy generation prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)